### PR TITLE
Umm/#252 extend studymanager frontend with observation groups

### DIFF
--- a/openapi/StudyManagerAPI.yaml
+++ b/openapi/StudyManagerAPI.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 info:
   version: 1.0.0
   title: StudyManager API
@@ -350,6 +350,10 @@ paths:
           in: query
           schema:
             $ref: '#/components/schemas/Id'
+        - name: observationGroup
+          in: query
+          schema:
+            $ref: '#/components/schemas/Id'
         - name: referenceDate
           in: query
           description: reference date used to calculate relative schedules
@@ -475,6 +479,110 @@ paths:
           description: Study group deleted
         '404':
           description: Not found
+
+  /studies/{studyId}/observationGroups:
+    post:
+      tags:
+        - observationGroups
+      operationId: createObservationGroup
+      description: Create a new observation group for a study
+      parameters:
+        - $ref: '#/components/parameters/StudyId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ObservationGroup'
+      responses:
+        '201':
+          description: Observation group successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ObservationGroup'
+        '400':
+          description: Observation group creation failed because of a bad request
+        '500':
+          description: Error while creating the observation group
+    get:
+      tags:
+        - observationGroups
+      description: List all observation groups for a study
+      operationId: listObservationGroups
+      parameters:
+        - $ref: '#/components/parameters/StudyId'
+      responses:
+        '200':
+          description: Successfully listed all observation groups
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ObservationGroup'
+        '404':
+          description: No study for the parsed studyId found
+
+  /studies/{studyId}/observationGroups/{observationGroupId}:
+    get:
+      tags:
+        - observationGroups
+      description: Get observation group information
+      operationId: getObservationGroup
+      parameters:
+        - $ref: '#/components/parameters/StudyId'
+        - $ref: '#/components/parameters/ObservationGroupId'
+      responses:
+        '200':
+          description: Successfully returned observation group information
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ObservationGroup'
+        '404':
+          description: Not found
+    put:
+      tags:
+        - observationGroups
+      description: Update a observation group
+      operationId: updateObservationGroup
+      parameters:
+        - $ref: '#/components/parameters/StudyId'
+        - $ref: '#/components/parameters/ObservationGroupId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ObservationGroup'
+      responses:
+        '200':
+          description: Successfully updated observation group
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ObservationGroup'
+        '400':
+          description: Could not update study group because of a bad request
+        '404':
+          description: Not found
+        '500':
+          description: Error while updating the observation group
+    delete:
+      tags:
+        - observationGroups
+      description: Delete a observation group
+      operationId: deleteObservationGroup
+      parameters:
+        - $ref: '#/components/parameters/StudyId'
+        - $ref: '#/components/parameters/ObservationGroupId'
+      responses:
+        '200':
+          description: Observation group deleted
+        '404':
+          description: Not found
+        '500':
+          description: Error while deleting the observation group
 
   /studies/{studyId}/participants:
     post:
@@ -1657,6 +1765,36 @@ components:
           type: string
           format: date-time
           readOnly: true
+    ObservationGroup:
+      type: object
+      properties:
+        studyId:
+          $ref: '#/components/schemas/StudyId'
+        observationGroupId:
+          $ref: '#/components/schemas/Id'
+        title:
+          type: string
+        purpose:
+          type: string
+        numberOfParticipants:
+          type: integer
+          readOnly: true
+        numberOfObservations:
+          type: integer
+          readOnly: true
+        numberOfInterventions:
+          type: integer
+          readOnly: true
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        modified:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+        - title
     StudyDuration:
       type: object
       properties:
@@ -1701,6 +1839,12 @@ components:
           type: string
           format: date-time
           readOnly: true
+        observationGroupIds:
+          type: array
+          description: The set of observation group Ids the participant is part of
+          items:
+            $ref: '#/components/schemas/IdReference'
+          uniqueItems: true
         created:
           type: string
           format: date-time
@@ -1746,11 +1890,6 @@ components:
             - $ref: './RelativeEvent.yaml/#/components/schemas/RelativeEvent'
           discriminator:
             propertyName: type
-            # mapping:
-            #   event:
-            #     $ref: './Event.yaml/#/components/schemas/Event'
-            #   relativeEvent:
-            #     $ref: './RelativeEvent.yaml/#/components/schemas/RelativeEvent'
         created:
           type: string
           format: date-time
@@ -1764,6 +1903,12 @@ components:
         noSchedule:
           type: boolean
           default: false
+        observationGroupIds:
+          type: array
+          description: The set of observation group Ids the observation is part of
+          items:
+            $ref: '#/components/schemas/IdReference'
+          uniqueItems: true
 
     OccurredObservation:
       type: object
@@ -1990,6 +2135,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Action'
+        observationGroupIds:
+          type: array
+          description: The set of observation group Ids the intervention is part of
+          items:
+            $ref: '#/components/schemas/IdReference'
+          uniqueItems: true
         created:
           type: string
           format: date-time
@@ -2059,6 +2210,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/StudyGroup'
+        observationGroups:
+          type: array
+          items:
+            $ref: '#/components/schemas/ObservationGroup'
         observations:
           type: array
           items:
@@ -2081,6 +2236,11 @@ components:
       properties:
         studyGroup:
           type: integer
+        observationGroups:
+          type: array
+          items:
+            type: integer
+          uniqueItems: true
 
     IntegrationInfo:
       type: object
@@ -2436,6 +2596,13 @@ components:
       required: true
     StudyGroupId:
       name: studyGroupId
+      in: path
+      schema:
+        type: integer
+        format: int32
+      required: true
+    ObservationGroupId:
+      name: observationGroupId
       in: path
       schema:
         type: integer

--- a/src/components/InterventionsList.vue
+++ b/src/components/InterventionsList.vue
@@ -230,7 +230,7 @@ Licensed under the Elastic License 2.0. */
                   studyGroupId: intervention.studyGroupId,
                   observationGroupIds: intervention.observationGroupIds,
                   observationGroupValues: intervention.observationGroupIds?.length
-                    ? intervention.observationGroupIds?.map((id) => observationGroupStatuses.find((group) => group.value === id.toString()))
+                    ? intervention.observationGroupIds?.map((id) => id.toString())
                     : [],
                   title: intervention.title,
                   purpose: intervention.purpose,
@@ -319,7 +319,7 @@ Licensed under the Elastic License 2.0. */
         newIntervention.interventionId as number,
         {
           ...newIntervention,
-          observationGroupIds: observationGroupValues?.map((group) => parseInt(group.value as string)) ?? []
+          observationGroupIds: observationGroupValues?.map((id: string) => parseInt(id)) ?? []
         },
       )
       .then(listInterventions)
@@ -494,7 +494,6 @@ Licensed under the Elastic License 2.0. */
           dialog.open(InterventionDialog, {
             data: {
               groupStates: groupStatuses,
-              observationGroupStates: observationGroupStatuses,
               intervention: intervention,
               studyId: props.studyId,
               actionsData: actionsRes,

--- a/src/components/InterventionsList.vue
+++ b/src/components/InterventionsList.vue
@@ -85,6 +85,10 @@ Licensed under the Elastic License 2.0. */
       }) as MoreTableChoice,
   );
 
+  function getObservationGroupItem(id: number): MoreTableChoice | undefined {
+    return observationGroupStatuses?.find((groupStatus) => groupStatus.value === id.toString())
+  }
+
   async function getActionFactories(): Promise<ComponentFactory[]> {
     return componentsApi
       .listComponents(ListComponentsComponentTypeEnum.Action)
@@ -230,7 +234,7 @@ Licensed under the Elastic License 2.0. */
                   studyGroupId: intervention.studyGroupId,
                   observationGroupIds: intervention.observationGroupIds,
                   observationGroupValues: intervention.observationGroupIds?.length
-                    ? intervention.observationGroupIds?.map((id) => id.toString())
+                    ? intervention.observationGroupIds?.map((id) => getObservationGroupItem(id))
                     : [],
                   title: intervention.title,
                   purpose: intervention.purpose,
@@ -319,7 +323,7 @@ Licensed under the Elastic License 2.0. */
         newIntervention.interventionId as number,
         {
           ...newIntervention,
-          observationGroupIds: observationGroupValues?.map((id: string) => parseInt(id)) ?? []
+          observationGroupIds: observationGroupValues?.map((choice: MoreTableChoice) => parseInt(choice.value as string)) ?? []
         },
       )
       .then(listInterventions)

--- a/src/components/InterventionsList.vue
+++ b/src/components/InterventionsList.vue
@@ -15,7 +15,7 @@ Licensed under the Elastic License 2.0. */
     ComponentFactory,
     StudyRole,
     StudyStatus,
-    ListComponentsComponentTypeEnum, Observation
+    ListComponentsComponentTypeEnum, Observation, ObservationGroup
   } from '@gs';
   import {
     MoreTableAction,
@@ -24,7 +24,7 @@ Licensed under the Elastic License 2.0. */
     MoreTableRowActionResult,
     MoreTableChoice,
     MoreTableSortOptions,
-    RowSelectionMode,
+    RowSelectionMode, MoreInterventionListTableRow
   } from '../models/MoreTableModel';
   import ConfirmDialog from 'primevue/confirmdialog';
   import DynamicDialog from 'primevue/dynamicdialog';
@@ -45,12 +45,13 @@ Licensed under the Elastic License 2.0. */
   const { t } = useI18n();
   const { handleIndividualError } = useErrorHandling();
 
-  const interventionList: Ref<Intervention[]> = ref([]);
+  const interventionList: Ref<MoreInterventionListTableRow[]> = ref([]);
   const dialog = useDialog();
 
   const props = defineProps({
     studyId: { type: Number, required: true },
     studyGroups: { type: Array as PropType<Array<StudyGroup>>, required: true },
+    observationGroups: { type: Array as PropType<Array<ObservationGroup>>, required: true},
     studyStatus: { type: String as PropType<StudyStatus>, required: true },
   });
 
@@ -75,6 +76,14 @@ Licensed under the Elastic License 2.0. */
     label: t('global.placeholder.entireStudy'),
     value: null,
   } as MoreTableChoice);
+
+  const observationGroupStatuses: MoreTableChoice[] = props.observationGroups.map(
+    (observationGroup) =>
+      ({
+        label: observationGroup.title,
+        value: observationGroup.observationGroupId?.toString(),
+      }) as MoreTableChoice,
+  );
 
   async function getActionFactories(): Promise<ComponentFactory[]> {
     return componentsApi
@@ -113,6 +122,19 @@ Licensed under the Elastic License 2.0. */
       filterable: true,
       placeholder: t('global.placeholder.entireStudy'),
       columnWidth: '10vw',
+    },
+    {
+      field: 'observationGroupValues',
+      header: t('observationGroup.plural'),
+      type: MoreTableFieldType.multiselect,
+      arrayLabels: observationGroupStatuses,
+      editable: {
+        enabled: actionsVisible,
+        values: observationGroupStatuses
+      },
+      sortable: true,
+      placeholder: t('global.placeholder.noGroup'),
+      columnWidth: '10vw'
     },
   ];
 
@@ -206,6 +228,10 @@ Licensed under the Elastic License 2.0. */
                   studyId: intervention.studyId,
                   interventionId: intervention.interventionId,
                   studyGroupId: intervention.studyGroupId,
+                  observationGroupIds: intervention.observationGroupIds,
+                  observationGroupValues: intervention.observationGroupIds?.length
+                    ? intervention.observationGroupIds?.map((id) => observationGroupStatuses.find((group) => group.value === id.toString()))
+                    : [],
                   title: intervention.title,
                   purpose: intervention.purpose,
                   schedule: intervention.schedule,
@@ -285,12 +311,16 @@ Licensed under the Elastic License 2.0. */
     }
   }
 
-  async function changeValue(intervention: Intervention): Promise<void> {
+  async function changeValue(intervention: MoreInterventionListTableRow): Promise<void> {
+    const {observationGroupValues, ...newIntervention} = intervention
     await interventionsApi
       .updateIntervention(
         props.studyId,
-        intervention.interventionId as number,
-        intervention,
+        newIntervention.interventionId as number,
+        {
+          ...newIntervention,
+          observationGroupIds: observationGroupValues?.map((group) => parseInt(group.value as string)) ?? []
+        },
       )
       .then(listInterventions)
       .catch((e: AxiosError) =>
@@ -464,6 +494,7 @@ Licensed under the Elastic License 2.0. */
           dialog.open(InterventionDialog, {
             data: {
               groupStates: groupStatuses,
+              observationGroupStates: observationGroupStatuses,
               intervention: intervention,
               studyId: props.studyId,
               actionsData: actionsRes,

--- a/src/components/ObservationGroupList.vue
+++ b/src/components/ObservationGroupList.vue
@@ -1,0 +1,187 @@
+/* Copyright UMM */
+<script setup lang="ts">
+  import { useObservationGroupStore } from '../stores/observationGroupStore';
+  import { useDialog } from 'primevue/usedialog';
+  import { useI18n } from 'vue-i18n';
+  import { computed, PropType } from 'vue';
+  import { ObservationGroup, StudyRole, StudyStatus } from '@gs';
+  import {
+    MoreTableAction,
+    MoreTableColumn,
+    MoreTableRowActionResult
+  } from '../models/MoreTableModel';
+  import DeleteMoreTableRowDialog from './dialog/DeleteMoreTableRowDialog.vue';
+  import Button from 'primevue/button';
+  import MoreTable from './shared/MoreTable.vue';
+  import ConfirmDialog from 'primevue/confirmdialog';
+
+  const observationGroupStore = useObservationGroupStore();
+  const dialog = useDialog();
+  const { t } = useI18n();
+
+  const props = defineProps({
+    studyId: {
+      type: Number,
+      required: true
+    },
+    userRoles: {
+      type: Array as PropType<Array<StudyRole>>,
+      required: true,
+    },
+    studyStatus: {
+      type: String as PropType<StudyStatus>,
+      required: true,
+    },
+  })
+
+  const observationGroups = computed(() => observationGroupStore.observationGroups);
+
+  const editableRoles: StudyRole[] = [
+    StudyRole.StudyAdmin,
+    StudyRole.StudyOperator,
+  ];
+
+  const actionsVisible =
+    (props.userRoles.some((r) => editableRoles.includes(r)) &&
+      props.studyStatus === StudyStatus.Draft) ||
+    (props.userRoles.some((r) => editableRoles.includes(r)) &&
+      props.studyStatus === StudyStatus.Paused) ||
+    (props.userRoles.some((r) => editableRoles.includes(r)) &&
+      props.studyStatus === StudyStatus.PausedPreview);
+
+  const observationGroupColumns: MoreTableColumn[] = [
+    {
+      field: 'observationGroupId',
+      header: t('global.labels.id'),
+      sortable: true
+    },
+    {
+      field: 'title',
+      placeholder: t('studyGroup.groupList.placeholder.title'),
+      header: t('study.props.title'),
+      editable: true,
+      columnWidth: '18vw',
+    },
+    {
+      field: 'purpose',
+      header: t('study.props.purpose'),
+      editable: true,
+      placeholder: t('studyGroup.groupList.placeholder.purpose'),
+      columnWidth: '20vw',
+    },
+    {
+      field: 'numberOfParticipants',
+      header: t('participants.plural'),
+      placeholder: '0',
+      columnWidth: '5vw'
+    },
+    {
+      field: 'numberOfObservations',
+      header: t('studyNavigation.tabs.observations'),
+      placeholder: '0',
+      columnWidth: '5vw'
+    },
+    {
+      field: 'numberOfInterventions',
+      header: t('studyNavigation.tabs.interventions'),
+      placeholder: '0',
+      columnWidth: '5vw'
+    }
+  ]
+
+  const rowActions: MoreTableAction[] = [
+    {
+      id: 'delete',
+      label: t('global.labels.delete'),
+      icon: 'pi pi-trash',
+      tooltip: t('tooltips.moreTable.deleteObservationGroupBtn'),
+      visible: () => actionsVisible,
+      confirmDeleteDialog: {
+        header: t('observationGroup.dialog.header.delete'),
+        message: t('observationGroup.dialog.msg.delete'),
+        dialog: (row: any) =>
+          dialog.open(DeleteMoreTableRowDialog, {
+            data: {
+              introMsg: t('observationGroup.dialog.deleteMsg.intro'),
+              warningMsg: t('observationGroup.dialog.deleteMsg.warning'),
+              confirmMsg: t('observationGroup.dialog.deleteMsg.confirm'),
+              row: row,
+              elTitle: row.title,
+              elInfoTitle: t('study.props.purpose'),
+              elInfoDesc: row.purpose,
+            },
+            props: {
+              header: t('observationGroup.dialog.header.delete'),
+              style: {
+                width: '50vw',
+              },
+              breakpoints: {
+                '960px': '75vw',
+                '640px': '90vw',
+              },
+              modal: true,
+              draggable: false,
+            },
+            onClose: (options) => {
+              if (options?.data) {
+                executeAction({
+                  id: 'delete',
+                  row: options.data,
+                } as MoreTableRowActionResult);
+              }
+            },
+          }),
+      },
+    },
+  ];
+
+  function executeAction(action: MoreTableRowActionResult): void {
+    const row = action.row
+
+    switch (action.id) {
+      case 'delete':
+        observationGroupStore.deleteObservationGroup(row as ObservationGroup);
+        break;
+      default:
+        console.error('no handler for action', action);
+    }
+  }
+
+  function changeValueInPlace(observationGroup: ObservationGroup): void {
+    observationGroupStore.updateObservationGroup(
+      props.studyId, observationGroup
+    );
+  }
+</script>
+
+<template>
+  <div>
+    <MoreTable
+      row-id="observationGroupId"
+      :title="$t('observationGroup.plural')"
+      :subtitle="$t('observationGroup.groupList.description')"
+      :columns="observationGroupColumns"
+      :rows="observationGroups"
+      :editable-access="actionsVisible"
+      :row-actions="rowActions"
+      :edit-access-roles="editableRoles"
+      :empty-message="$t('observationGroup.groupList.placeholder.emptyGroupList')"
+      class="table-title-width"
+      @on-action="executeAction($event)"
+      @on-change="changeValueInPlace($event)"
+    >
+      <template #tableActions>
+        <div>
+          <Button
+            type="button"
+            icon="pi pi-plus"
+            :label="t('observationGroup.dialog.header.create')"
+            :disabled="!actionsVisible"
+            @click="observationGroupStore.createObservationGroups(props.studyId)"
+          />
+        </div>
+      </template>
+    </MoreTable>
+    <ConfirmDialog></ConfirmDialog>
+  </div>
+</template>

--- a/src/components/ObservationList.vue
+++ b/src/components/ObservationList.vue
@@ -265,7 +265,7 @@ Licensed under the Elastic License 2.0. */
             studyGroupId: observation.studyGroupId,
             observationGroupIds: observation.observationGroupIds,
             observationGroupValues: observation.observationGroupIds?.length
-              ? observation.observationGroupIds.map((id) => observationGroupStatuses?.find((group) => group.value === id.toString()))
+              ? observation.observationGroupIds.map((id: number) => id.toString())
               : [],
             title: observation.title,
             purpose: observation.purpose,
@@ -372,7 +372,7 @@ Licensed under the Elastic License 2.0. */
     }
   }
 
-  async function updateObservation(observation: MoreObservationListTableRow): Promise<void> {
+  async function updateObservation(observation: MoreObservationListTableRow, fromDialog: boolean = false): Promise<void> {
     const {observationGroupValues, ...newObservation} = observation;
 
     await observationsApi
@@ -381,7 +381,7 @@ Licensed under the Elastic License 2.0. */
         newObservation.observationId as number,
         {
           ...newObservation,
-          observationGroupIds: observationGroupValues?.map((group) => parseInt(group.value as string))
+          observationGroupIds: fromDialog ? newObservation.observationGroupIds : observationGroupValues?.map((id: string) => parseInt(id))
         },
       )
       .then(listObservations)
@@ -422,7 +422,6 @@ Licensed under the Elastic License 2.0. */
     dialog.open(ObservationDialog, {
       data: {
         groupStates: groupStatuses,
-        observationGroupStates: observationGroupStatuses,
         observation: observation,
         factory: factoryForType(observation?.type),
         closeWithEscape: false,
@@ -447,7 +446,7 @@ Licensed under the Elastic License 2.0. */
             if (clone) {
               createObservation(options.data as Observation);
             } else {
-              updateObservation(options.data as Observation);
+              updateObservation(options.data as Observation, true);
             }
           } else {
             createObservation(options.data as Observation);

--- a/src/components/ObservationList.vue
+++ b/src/components/ObservationList.vue
@@ -9,21 +9,22 @@ Licensed under the Elastic License 2.0. */
   import {
     ComponentFactory,
     Event,
-    Observation,
+    Observation, ObservationGroup,
     ObservationSchedule,
     RelativeEvent,
     StudyGroup,
     StudyRole,
-    StudyStatus,
+    StudyStatus
   } from '@gs';
   import {
+    MoreObservationListTableRow,
     MoreTableAction,
     MoreTableChoice,
     MoreTableColumn,
     MoreTableFieldType,
     MoreTableRowActionResult,
     MoreTableSortOptions,
-    RowSelectionMode,
+    RowSelectionMode
   } from '../models/MoreTableModel';
   import ConfirmDialog from 'primevue/confirmdialog';
   import DynamicDialog from 'primevue/dynamicdialog';
@@ -46,13 +47,14 @@ Licensed under the Elastic License 2.0. */
   const { t, d } = useI18n();
   const { handleIndividualError } = useErrorHandling();
 
-  const observationList: Ref<Observation[]> = ref([]);
+  const observationList: Ref<MoreObservationListTableRow[]> = ref([]);
   const dialog = useDialog();
 
   const props = defineProps({
     studyId: { type: Number, required: true },
     studyGroups: { type: Array as PropType<Array<StudyGroup>>, required: true },
     studyStatus: { type: String as PropType<StudyStatus>, required: true },
+    observationGroups: { type: Array as PropType<Array<ObservationGroup>>, required: true}
   });
 
   const sortOptions: MoreTableSortOptions = {
@@ -76,6 +78,14 @@ Licensed under the Elastic License 2.0. */
     label: t('global.placeholder.entireStudy'),
     value: null,
   } as MoreTableChoice);
+
+  const observationGroupStatuses: MoreTableChoice[] = props.observationGroups.map(
+    (observationGroup) =>
+      ({
+        label: observationGroup.title,
+        value: observationGroup.observationGroupId?.toString(),
+      }) as MoreTableChoice,
+  );
 
   async function getFactories(): Promise<ComponentFactory[]> {
     return componentsApi
@@ -126,6 +136,19 @@ Licensed under the Elastic License 2.0. */
       filterable: true,
       placeholder: t('global.placeholder.entireStudy'),
       columnWidth: '5vw',
+    },
+    {
+      field: 'observationGroupValues',
+      header: t('observationGroup.plural'),
+      type: MoreTableFieldType.multiselect,
+      arrayLabels: observationGroupStatuses,
+      editable: {
+        enabled: actionsVisible,
+        values: observationGroupStatuses
+      },
+      sortable: true,
+      placeholder: t('global.placeholder.noGroup'),
+      columnWidth: '10vw'
     },
     {
       field: 'hidden',
@@ -240,6 +263,10 @@ Licensed under the Elastic License 2.0. */
             studyId: observation.studyId,
             observationId: observation.observationId,
             studyGroupId: observation.studyGroupId,
+            observationGroupIds: observation.observationGroupIds,
+            observationGroupValues: observation.observationGroupIds?.length
+              ? observation.observationGroupIds.map((id) => observationGroupStatuses?.find((group) => group.value === id.toString()))
+              : [],
             title: observation.title,
             purpose: observation.purpose,
             participantInfo: observation.participantInfo,
@@ -345,12 +372,17 @@ Licensed under the Elastic License 2.0. */
     }
   }
 
-  async function updateObservation(observation: Observation): Promise<void> {
+  async function updateObservation(observation: MoreObservationListTableRow): Promise<void> {
+    const {observationGroupValues, ...newObservation} = observation;
+
     await observationsApi
       .updateObservation(
         props.studyId,
-        observation.observationId as number,
-        observation,
+        newObservation.observationId as number,
+        {
+          ...newObservation,
+          observationGroupIds: observationGroupValues?.map((group) => parseInt(group.value as string))
+        },
       )
       .then(listObservations)
       .catch((e: AxiosError) =>
@@ -390,6 +422,7 @@ Licensed under the Elastic License 2.0. */
     dialog.open(ObservationDialog, {
       data: {
         groupStates: groupStatuses,
+        observationGroupStates: observationGroupStatuses,
         observation: observation,
         factory: factoryForType(observation?.type),
         closeWithEscape: false,

--- a/src/components/ObservationList.vue
+++ b/src/components/ObservationList.vue
@@ -254,6 +254,10 @@ Licensed under the Elastic License 2.0. */
     );
   }
 
+  function getObservationGroupItem(id: number): MoreTableChoice | undefined {
+    return observationGroupStatuses?.find((groupStatus) => groupStatus.value === id.toString())
+  }
+
   async function listObservations(): Promise<void> {
     observationList.value = await observationsApi
       .listObservations(props.studyId)
@@ -265,7 +269,7 @@ Licensed under the Elastic License 2.0. */
             studyGroupId: observation.studyGroupId,
             observationGroupIds: observation.observationGroupIds,
             observationGroupValues: observation.observationGroupIds?.length
-              ? observation.observationGroupIds.map((id: number) => id.toString())
+              ? observation.observationGroupIds.map((id: number) => getObservationGroupItem(id))
               : [],
             title: observation.title,
             purpose: observation.purpose,
@@ -381,7 +385,7 @@ Licensed under the Elastic License 2.0. */
         newObservation.observationId as number,
         {
           ...newObservation,
-          observationGroupIds: fromDialog ? newObservation.observationGroupIds : observationGroupValues?.map((id: string) => parseInt(id))
+          observationGroupIds: fromDialog ? newObservation.observationGroupIds : observationGroupValues?.map((choice: MoreTableChoice) => parseInt(choice.value as string))
         },
       )
       .then(listObservations)

--- a/src/components/ParticipantList.vue
+++ b/src/components/ParticipantList.vue
@@ -211,6 +211,11 @@ Licensed under the Elastic License 2.0. */
       command: (): void => createParticipant(count),
     }),
   );
+
+  function getObservationGroupItem(id: number): MoreTableChoice | undefined {
+    return observationGroupStatuses?.find((groupStatus) => groupStatus.value === id.toString())
+  }
+
   async function listParticipant(): Promise<void> {
     participantsList.value = await participantsApi
       .listParticipants(props.studyId)
@@ -218,7 +223,8 @@ Licensed under the Elastic License 2.0. */
         return response.data.map((participant) => {
           return {
             ...participant,
-            observationGroupValues: participant?.observationGroupIds?.map((id) => id.toString()) ?? []
+            observationGroupValues: participant?.observationGroupIds?.map((id: number) =>
+              getObservationGroupItem(id))
           } as MoreParticipantListTableRow
         }) ?? []
       })
@@ -376,7 +382,7 @@ Licensed under the Elastic License 2.0. */
         participant.participantId as number,
         {
           ...newParticipant,
-          observationGroupIds: observationGroupValues?.map((id: string) => parseInt(id)) ?? []
+          observationGroupIds: observationGroupValues?.map((choice: MoreTableChoice) => parseInt(choice.value as string)) ?? []
         }
       );
     }

--- a/src/components/ParticipantList.vue
+++ b/src/components/ParticipantList.vue
@@ -8,14 +8,15 @@ Licensed under the Elastic License 2.0. */
   import { useImportExportApi, useParticipantsApi } from '../composable/useApi';
 
   import {
+    MoreParticipantListTableRow,
     MoreTableAction,
     MoreTableChoice,
     MoreTableColumn,
     MoreTableFieldType,
     MoreTableRowActionResult,
-    MoreTableSortOptions,
+    MoreTableSortOptions
   } from '../models/MoreTableModel';
-  import { Participant, StudyGroup, StudyRole, StudyStatus } from '@gs';
+  import { ObservationGroup, Participant, StudyGroup, StudyRole, StudyStatus } from '@gs';
   import MoreTable from './shared/MoreTable.vue';
   import ConfirmDialog from 'primevue/confirmdialog';
   import DynamicDialog from 'primevue/dynamicdialog';
@@ -30,18 +31,14 @@ Licensed under the Elastic License 2.0. */
   import Button from 'primevue/button';
   import FileUpload, { FileUploadUploaderEvent } from 'primevue/fileupload';
   import { MenuOptions } from '../models/ComponentModels';
-  import {
-    ACTION_ID_DATA_HEALTH,
-    ACTION_ID_DELETE,
-    ACTION_ID_QR_CODE,
-    PARTICIPANT_COUNTS,
-  } from '../constants';
+  import { ACTION_ID_DATA_HEALTH, ACTION_ID_DELETE, ACTION_ID_QR_CODE, PARTICIPANT_COUNTS } from '../constants';
   import QrCodeDialog from './dialog/QrCodeDialog.vue';
   import ParticipantDetailsDialog from './dialog/ParticipantDetailsDialog.vue';
 
   const { participantsApi } = useParticipantsApi();
   const { importExportApi } = useImportExportApi();
-  const participantsList: Ref<Participant[]> = ref([]);
+
+  const participantsList: Ref<MoreParticipantListTableRow[]> = ref([]);
   const loader = useLoader();
   const { t } = useI18n();
   const { handleIndividualError } = useErrorHandling();
@@ -57,6 +54,7 @@ Licensed under the Elastic License 2.0. */
       required: true,
     },
     studyGroups: { type: Array as PropType<Array<StudyGroup>>, required: true },
+    observationGroups: { type: Array as PropType<Array<ObservationGroup>>, required: true}
   });
 
   const sortOptions: MoreTableSortOptions = {
@@ -80,6 +78,14 @@ Licensed under the Elastic License 2.0. */
     label: t('global.placeholder.noGroup'),
     value: null,
   } as MoreTableChoice);
+
+  const observationGroupStatuses: MoreTableChoice[] = props.observationGroups.map(
+    (observationGroup) =>
+      ({
+        label: observationGroup.title,
+        value: observationGroup.observationGroupId?.toString(),
+      }) as MoreTableChoice,
+  );
 
   const participantsColumns: MoreTableColumn[] = [
     { field: 'participantId', header: t('global.labels.id'), sortable: true },
@@ -106,6 +112,19 @@ Licensed under the Elastic License 2.0. */
       filterable: true,
       placeholder: t('global.placeholder.noGroup'),
       columnWidth: '15vw',
+    },
+    {
+      field: 'observationGroupValues',
+      header: t('observationGroup.plural'),
+      type: MoreTableFieldType.multiselect,
+      arrayLabels: observationGroupStatuses,
+      editable: {
+        enabled: actionsVisible,
+        values: observationGroupStatuses
+      },
+      sortable: true,
+      placeholder: t('global.placeholder.noGroup'),
+      columnWidth: '10vw'
     },
     {
       field: 'start',
@@ -195,7 +214,15 @@ Licensed under the Elastic License 2.0. */
   async function listParticipant(): Promise<void> {
     participantsList.value = await participantsApi
       .listParticipants(props.studyId)
-      .then((response) => response.data)
+      .then((response) => {
+        return response.data.map((participant) => {
+          let observationChoices = participant?.observationGroupIds?.map((id) => observationGroupStatuses?.find((group) => group?.value === id.toString()))
+          return {
+            ...participant,
+            observationGroupValues: observationChoices
+          } as MoreParticipantListTableRow
+        }) ?? []
+      })
       .catch((e: AxiosError) => {
         handleIndividualError(e, 'cannot list participants');
         return participantsList.value;
@@ -337,16 +364,21 @@ Licensed under the Elastic License 2.0. */
       .then(listParticipant);
   };
 
-  function changeValue(participant: Participant): void {
+  function changeValue(participant: MoreParticipantListTableRow): void {
     const i = participantsList.value.findIndex(
       (v) => v.participantId === participant.participantId,
     );
     if (i > -1) {
       participantsList.value[i] = participant;
+      const { observationGroupValues, ...newParticipant } = participant
+
       participantsApi.updateParticipant(
         participant.studyId as number,
         participant.participantId as number,
-        participant,
+        {
+          ...newParticipant,
+          observationGroupIds: observationGroupValues?.map((group: MoreTableChoice) => parseInt(group.value as string)) ?? []
+        }
       );
     }
   }
@@ -432,6 +464,7 @@ Licensed under the Elastic License 2.0. */
 <template>
   <div class="participant-list">
     <MoreTable
+      v-if="!!observationGroupStatuses"
       row-id="participantId"
       :sort-options="sortOptions"
       :title="$t('participants.participantsList.title')"

--- a/src/components/ParticipantList.vue
+++ b/src/components/ParticipantList.vue
@@ -216,10 +216,9 @@ Licensed under the Elastic License 2.0. */
       .listParticipants(props.studyId)
       .then((response) => {
         return response.data.map((participant) => {
-          let observationChoices = participant?.observationGroupIds?.map((id) => observationGroupStatuses?.find((group) => group?.value === id.toString()))
           return {
             ...participant,
-            observationGroupValues: observationChoices
+            observationGroupValues: participant?.observationGroupIds?.map((id) => id.toString()) ?? []
           } as MoreParticipantListTableRow
         }) ?? []
       })
@@ -377,7 +376,7 @@ Licensed under the Elastic License 2.0. */
         participant.participantId as number,
         {
           ...newParticipant,
-          observationGroupIds: observationGroupValues?.map((group: MoreTableChoice) => parseInt(group.value as string)) ?? []
+          observationGroupIds: observationGroupValues?.map((id: string) => parseInt(id)) ?? []
         }
       );
     }

--- a/src/components/dialog/InterventionDialog.vue
+++ b/src/components/dialog/InterventionDialog.vue
@@ -569,7 +569,7 @@ Licensed under the Elastic License 2.0. */
           {{ editable ? $t('study.dialog.label.chooseGroups') : $t('study.props.groups') }}
         </h5>
         <div v-if="editable" class="mb-2">
-          {{ $t('study.dialog.description.howToCreateGroups') }}
+          {{ $t('study.dialog.description.howToCreateGroups', {for: $t('intervention.plural')}) }}
         </div>
         <div class="flex gap-5">
         <div>

--- a/src/components/dialog/InterventionDialog.vue
+++ b/src/components/dialog/InterventionDialog.vue
@@ -565,9 +565,12 @@ Licensed under the Elastic License 2.0. */
       </div>
 
       <div class="col-start-0 col-span-8">
-        <h5 v-if="!editable" class="pb-2 font-bold">
-          {{ $t('study.props.studyGroup') }}
+        <h5 v-if="editable" class="pb-2 font-bold">
+          {{ editable ? $t('study.dialog.label.chooseGroups') : $t('study.props.groups') }}
         </h5>
+        <div v-if="editable" class="mb-2">
+          {{ $t('study.dialog.description.howToCreateGroups') }}
+        </div>
         <div class="flex gap-5">
         <div>
           <div class="mb-1">{{ $t('studyGroup.plural')}}</div>
@@ -596,10 +599,10 @@ Licensed under the Elastic License 2.0. */
           </div>
           <div>
             <div class="mb-1">{{ $t('observationGroup.plural') }}</div>
-            <div>{{selectedObservationGroups}}</div>
             <MultiSelect
               v-model="selectedObservationGroups"
               :options="observationGroupStates"
+              :disabled="!editable"
               option-label="label"
               option-value="value"
               :placeholder="$t('global.placeholder.chooseDropdownOptionDefault')"

--- a/src/components/dialog/InterventionDialog.vue
+++ b/src/components/dialog/InterventionDialog.vue
@@ -29,9 +29,11 @@ Licensed under the Elastic License 2.0. */
   import ActionProperty from './shared/ActionProperty.vue';
   import { PropertyEmit, StringEmit } from '../../models/PropertyInputModels';
   import MultiSelect from 'primevue/multiselect';
+  import { useObservationGroupStore } from '../../stores/observationGroupStore';
 
   const { componentsApi } = useComponentsApi();
   const studyStore = useStudyStore();
+  const observationGroupStore = useObservationGroupStore();
   const { t } = useI18n();
 
   const dialogRef: any = inject('dialogRef');
@@ -40,14 +42,20 @@ Licensed under the Elastic License 2.0. */
   const triggerData: Trigger = dialogRef.value.data?.triggerData;
   const groupStates: MoreTableChoice[] =
     dialogRef.value.data?.groupStates || [];
-  const observationGroupStates = dialogRef.value.data.observationGroupStates || [];
+  const observationGroupStates: MoreTableChoice[] = observationGroupStore.observationGroups.map(
+    (observationGroup) =>
+      ({
+        label: observationGroup.title,
+        value: observationGroup.observationGroupId?.toString(),
+      }) as MoreTableChoice,
+  );
   const groupPlaceholder =
     dialogRef.value.data?.groupPlaceholder ||
     t('global.placeholder.entireStudy');
   const actionFactories = dialogRef.value.data?.actionFactories;
   const triggerFactories = dialogRef.value.data?.triggerFactories;
   const selectedObservationGroups = ref(
-    intervention.observationGroupIds?.map((id) => observationGroupStates.value.find((group: MoreTableChoice) => group.value === id.toString())) ?? []
+    intervention.observationGroupIds?.map((id: number) => id.toString()) ?? []
   )
 
   let propInputError: string = '';
@@ -230,7 +238,7 @@ Licensed under the Elastic License 2.0. */
             trigger: {},
             actions: [],
             studyGroupId: studyGroupId.value,
-            observationGroupIds: selectedObservationGroups.value?.length ? selectedObservationGroups.value.map((group) => group.value) : [],
+            observationGroupIds: selectedObservationGroups.value?.length ? selectedObservationGroups.value.map((id: string) => parseInt(id)) : [],
             schedule: intervention.schedule,
           } as Intervention;
 
@@ -588,6 +596,7 @@ Licensed under the Elastic License 2.0. */
           </div>
           <div>
             <div class="mb-1">{{ $t('observationGroup.plural') }}</div>
+            <div>{{selectedObservationGroups}}</div>
             <MultiSelect
               v-model="selectedObservationGroups"
               :options="observationGroupStates"

--- a/src/components/dialog/InterventionDialog.vue
+++ b/src/components/dialog/InterventionDialog.vue
@@ -28,6 +28,7 @@ Licensed under the Elastic License 2.0. */
   import { CronProperty, Property } from '../../models/InputModels';
   import ActionProperty from './shared/ActionProperty.vue';
   import { PropertyEmit, StringEmit } from '../../models/PropertyInputModels';
+  import MultiSelect from 'primevue/multiselect';
 
   const { componentsApi } = useComponentsApi();
   const studyStore = useStudyStore();
@@ -39,11 +40,15 @@ Licensed under the Elastic License 2.0. */
   const triggerData: Trigger = dialogRef.value.data?.triggerData;
   const groupStates: MoreTableChoice[] =
     dialogRef.value.data?.groupStates || [];
+  const observationGroupStates = dialogRef.value.data.observationGroupStates || [];
   const groupPlaceholder =
     dialogRef.value.data?.groupPlaceholder ||
     t('global.placeholder.entireStudy');
   const actionFactories = dialogRef.value.data?.actionFactories;
   const triggerFactories = dialogRef.value.data?.triggerFactories;
+  const selectedObservationGroups = ref(
+    intervention.observationGroupIds?.map((id) => observationGroupStates.value.find((group: MoreTableChoice) => group.value === id.toString())) ?? []
+  )
 
   let propInputError: string = '';
 
@@ -225,6 +230,7 @@ Licensed under the Elastic License 2.0. */
             trigger: {},
             actions: [],
             studyGroupId: studyGroupId.value,
+            observationGroupIds: selectedObservationGroups.value?.length ? selectedObservationGroups.value.map((group) => group.value) : [],
             schedule: intervention.schedule,
           } as Intervention;
 
@@ -554,28 +560,57 @@ Licensed under the Elastic License 2.0. */
         <h5 v-if="!editable" class="pb-2 font-bold">
           {{ $t('study.props.studyGroup') }}
         </h5>
-        <Dropdown
-          v-model="studyGroupId"
-          :options="groupStates"
-          option-label="label"
-          option-value="value"
-          :disabled="!editable"
-          class="w-fit"
-          :class="{ 'dropdown-has-value': studyGroupId }"
-          :placeholder="
-            studyGroupId
-              ? getLabelForChoiceValue(studyGroupId as number, groupStates)
-              : groupPlaceholder
-                ? (groupPlaceholder as string)
-                : $t('global.placeholder.entireStudy')
-          "
-        >
-          <template #option="optionProps">
-            <div class="p-dropdown-car-option">
-              <span>{{ optionProps.option.label }}</span>
-            </div>
-          </template>
-        </Dropdown>
+        <div class="flex gap-5">
+        <div>
+          <div class="mb-1">{{ $t('studyGroup.plural')}}</div>
+            <Dropdown
+            v-model="studyGroupId"
+            :options="groupStates"
+            option-label="label"
+            option-value="value"
+            :disabled="!editable"
+            class="w-fit"
+            :class="{ 'dropdown-has-value': studyGroupId }"
+            :placeholder="
+              studyGroupId
+                ? getLabelForChoiceValue(studyGroupId as number, groupStates)
+                : groupPlaceholder
+                  ? (groupPlaceholder as string)
+                  : $t('global.placeholder.entireStudy')
+            "
+          >
+            <template #option="optionProps">
+              <div class="p-dropdown-car-option">
+                <span>{{ optionProps.option.label }}</span>
+              </div>
+            </template>
+          </Dropdown>
+          </div>
+          <div>
+            <div class="mb-1">{{ $t('observationGroup.plural') }}</div>
+            <MultiSelect
+              v-model="selectedObservationGroups"
+              :options="observationGroupStates"
+              option-label="label"
+              option-value="value"
+              :placeholder="$t('global.placeholder.chooseDropdownOptionDefault')"
+              :show-toggle-all="false"
+              class="z-top custom-multiselect-root"
+              :panel-class="'custom-multiselect-panel'"
+            >
+              <template #value="{ value }">
+                      <span v-if="value?.length === 1">{{ observationGroupStates.find(
+                        (group: MoreTableChoice) => group.value === value[0]
+                      )?.label }}</span>
+                <span v-else-if="value?.length >= 2">{{ value.length }} {{ $t('global.placeholder.selected') }}</span>
+                <span v-else class="text-gray-400">
+                        {{ $t('global.placeholder.chooseDropdownOptionDefault') }}
+                      </span>
+              </template>
+
+            </MultiSelect>
+          </div>
+        </div>
       </div>
 
       <div

--- a/src/components/dialog/ObservationDialog.vue
+++ b/src/components/dialog/ObservationDialog.vue
@@ -32,18 +32,26 @@ Licensed under the Elastic License 2.0. */
   import { useErrorHandling } from '../../composable/useErrorHandling';
   import { useToastService } from '../../composable/toastService';
   import MultiSelect from 'primevue/multiselect';
+  import { useObservationGroupStore } from '../../stores/observationGroupStore';
 
   const { handleToastErrors, showErrorToast } = useToastService();
   const dialog = useDialog();
   const { componentsApi } = useComponentsApi();
   const { handleIndividualError } = useErrorHandling();
   const studyStore = useStudyStore();
+  const observationGroupStore = useObservationGroupStore();
   const { t } = useI18n();
 
   const dialogRef: any = inject('dialogRef');
   const observation = dialogRef.value.data.observation as Observation;
   const groupStates = dialogRef.value.data.groupStates || [];
-  const observationGroupStates = dialogRef.value.data.observationGroupStates || [];
+  const observationGroupStates: MoreTableChoice[] = observationGroupStore.observationGroups.map(
+    (observationGroup) =>
+      ({
+        label: observationGroup.title,
+        value: observationGroup.observationGroupId?.toString(),
+      }) as MoreTableChoice,
+  );
   const factory = dialogRef.value.data.factory;
   const editable =
     studyStore.study.status === StudyStatus.Draft ||
@@ -59,7 +67,7 @@ Licensed under the Elastic License 2.0. */
       .map((p: Property<any>) => p.setValue(observation.properties?.[p.id])),
   );
   const selectedObservationGroups = ref(
-    observation.observationGroupIds?.map((id) => observationGroupStates.value.find((group: MoreTableChoice) => group.value === id.toString())) ?? []
+    observation.observationGroupIds?.map((id: number) => id.toString()) ?? []
   )
 
   const hidden: Ref<boolean> = ref(
@@ -178,7 +186,7 @@ Licensed under the Elastic License 2.0. */
       title: title.value,
       purpose: purpose.value,
       participantInfo: participantInfo.value,
-      observationGroupIds: selectedObservationGroups.value?.length ? selectedObservationGroups.value.map((group) => group.value) : [],
+      observationGroupIds: selectedObservationGroups.value?.length ? selectedObservationGroups.value.map((id: string) => parseInt(id)) : [],
       type: observation.type,
       properties: props,
       schedule: scheduler.value,
@@ -340,6 +348,7 @@ Licensed under the Elastic License 2.0. */
             </div>
             <div>
               <div class="mb-1">{{ $t('observationGroup.plural') }}</div>
+              <div>{{selectedObservationGroups}}</div>
                 <MultiSelect
                   v-model="selectedObservationGroups"
                   :options="observationGroupStates"

--- a/src/components/dialog/ObservationDialog.vue
+++ b/src/components/dialog/ObservationDialog.vue
@@ -327,9 +327,12 @@ Licensed under the Elastic License 2.0. */
 
       <div class="col-start-0 col-span-8 flex items-center justify-between">
         <div>
-          <h5 v-if="!editable" class="pb-2 font-bold">
-            {{ $t('study.props.studyGroup') }}
+          <h5 v-if="editable" class="pb-2 font-bold">
+            {{ editable ? $t('study.dialog.label.chooseGroups') : $t('study.props.groups') }}
           </h5>
+          <div v-if="editable" class="mb-2">
+            {{ $t('study.dialog.description.howToCreateGroups') }}
+          </div>
           <div class="flex gap-5">
             <div>
               <div class="mb-1">{{ $t('studyGroup.plural')}}</div>
@@ -348,10 +351,10 @@ Licensed under the Elastic License 2.0. */
             </div>
             <div>
               <div class="mb-1">{{ $t('observationGroup.plural') }}</div>
-              <div>{{selectedObservationGroups}}</div>
                 <MultiSelect
                   v-model="selectedObservationGroups"
                   :options="observationGroupStates"
+                  :disabled="!editable"
                   option-label="label"
                   option-value="value"
                   :placeholder="$t('global.placeholder.chooseDropdownOptionDefault')"
@@ -373,17 +376,14 @@ Licensed under the Elastic License 2.0. */
               </div>
           </div>
         </div>
+      </div>
 
+      <div
+        class="col-start-0 buttons col-span-8 mt-1 grid grid-cols-2"
+      >
         <div
           class="info-box relative flex cursor-pointer flex-row items-center"
         >
-          <span class="ml-1 inline">
-            {{ $t(`observation.props.hidden.${hidden}`) }}
-          </span>
-          <i
-            class="pi pi-info-circle color-primary mx-1"
-            :class="{ 'me-2': editable && factory.visibility.changeable }"
-          />
           <div
             v-if="editable && factory.visibility.changeable"
             class="flex items-center"
@@ -413,12 +413,15 @@ Licensed under the Elastic License 2.0. */
               {{ $t('observation.dialog.msg.hiddenInfo') }}
             </div>
           </div>
+          <span class="ml-2 inline">
+            {{ $t(`observation.props.hidden.${hidden}`) }}
+          </span>
+          <i
+            class="pi pi-info-circle color-primary mx-1"
+            :class="{ 'me-2': editable && factory.visibility.changeable }"
+          />
         </div>
-      </div>
-
-      <div
-        class="col-start-0 buttons col-span-8 mt-1 flex flex-row items-center justify-end text-right"
-      >
+        <div class="flex flex-row items-center justify-end text-right">
         <Button class="btn-gray" @click="cancel()">
           <span v-if="editable">{{ $t('global.labels.cancel') }}</span>
           <span v-else>{{ $t('global.labels.close') }}</span>
@@ -430,6 +433,7 @@ Licensed under the Elastic License 2.0. */
           :disabled="!editable"
           @click="checkRequiredFields()"
         />
+        </div>
       </div>
     </form>
   </div>

--- a/src/components/dialog/ObservationDialog.vue
+++ b/src/components/dialog/ObservationDialog.vue
@@ -331,7 +331,7 @@ Licensed under the Elastic License 2.0. */
             {{ editable ? $t('study.dialog.label.chooseGroups') : $t('study.props.groups') }}
           </h5>
           <div v-if="editable" class="mb-2">
-            {{ $t('study.dialog.description.howToCreateGroups') }}
+            {{ $t('study.dialog.description.howToCreateGroups', {for: $t('studyNavigation.tabs.observations')}) }}
           </div>
           <div class="flex gap-5">
             <div>

--- a/src/components/dialog/ObservationDialog.vue
+++ b/src/components/dialog/ObservationDialog.vue
@@ -31,6 +31,7 @@ Licensed under the Elastic License 2.0. */
   import { AxiosError } from 'axios';
   import { useErrorHandling } from '../../composable/useErrorHandling';
   import { useToastService } from '../../composable/toastService';
+  import MultiSelect from 'primevue/multiselect';
 
   const { handleToastErrors, showErrorToast } = useToastService();
   const dialog = useDialog();
@@ -42,6 +43,7 @@ Licensed under the Elastic License 2.0. */
   const dialogRef: any = inject('dialogRef');
   const observation = dialogRef.value.data.observation as Observation;
   const groupStates = dialogRef.value.data.groupStates || [];
+  const observationGroupStates = dialogRef.value.data.observationGroupStates || [];
   const factory = dialogRef.value.data.factory;
   const editable =
     studyStore.study.status === StudyStatus.Draft ||
@@ -56,6 +58,9 @@ Licensed under the Elastic License 2.0. */
       .map((json: any) => Property.fromJson(json))
       .map((p: Property<any>) => p.setValue(observation.properties?.[p.id])),
   );
+  const selectedObservationGroups = ref(
+    observation.observationGroupIds?.map((id) => observationGroupStates.value.find((group: MoreTableChoice) => group.value === id.toString())) ?? []
+  )
 
   const hidden: Ref<boolean> = ref(
     observation.hidden !== undefined
@@ -173,6 +178,7 @@ Licensed under the Elastic License 2.0. */
       title: title.value,
       purpose: purpose.value,
       participantInfo: participantInfo.value,
+      observationGroupIds: selectedObservationGroups.value?.length ? selectedObservationGroups.value.map((group) => group.value) : [],
       type: observation.type,
       properties: props,
       schedule: scheduler.value,
@@ -316,18 +322,47 @@ Licensed under the Elastic License 2.0. */
           <h5 v-if="!editable" class="pb-2 font-bold">
             {{ $t('study.props.studyGroup') }}
           </h5>
-          <Dropdown
-            v-model="studyGroupId"
-            :options="groupStates"
-            option-label="label"
-            option-value="value"
-            :disabled="!editable"
-            :class="{ 'dropdown-has-value': studyGroupId }"
-            :placeholder="
-              getLabelForChoiceValue(studyGroupId, groupStates) ||
-              $t('global.placeholder.entireStudy')
-            "
-          />
+          <div class="flex gap-5">
+            <div>
+              <div class="mb-1">{{ $t('studyGroup.plural')}}</div>
+              <Dropdown
+                v-model="studyGroupId"
+                :options="groupStates"
+                option-label="label"
+                option-value="value"
+                :disabled="!editable"
+                :class="{ 'dropdown-has-value': studyGroupId }"
+                :placeholder="
+                  getLabelForChoiceValue(studyGroupId, groupStates) ||
+                  $t('global.placeholder.entireStudy')
+                "
+              />
+            </div>
+            <div>
+              <div class="mb-1">{{ $t('observationGroup.plural') }}</div>
+                <MultiSelect
+                  v-model="selectedObservationGroups"
+                  :options="observationGroupStates"
+                  option-label="label"
+                  option-value="value"
+                  :placeholder="$t('global.placeholder.chooseDropdownOptionDefault')"
+                  :show-toggle-all="false"
+                  class="z-top custom-multiselect-root"
+                  :panel-class="'custom-multiselect-panel'"
+                >
+                  <template #value="{ value }">
+                    <span v-if="value?.length === 1">{{ observationGroupStates.find(
+                      (group: MoreTableChoice) => group.value === value[0]
+                    )?.label }}</span>
+                    <span v-else-if="value?.length >= 2"> {{ value.length }} {{ $t('global.placeholder.selected')}}</span>
+                    <span v-else class="text-gray-400">
+                      {{ $t('global.placeholder.chooseDropdownOptionDefault') }}
+                    </span>
+                  </template>
+
+                </MultiSelect>
+              </div>
+          </div>
         </div>
 
         <div

--- a/src/components/shared/MoreTable.vue
+++ b/src/components/shared/MoreTable.vue
@@ -478,61 +478,6 @@ Licensed under the Elastic License 2.0. */
             :show-toggle-all="false"
             class="z-top"
           />
-          <!--<MultiSelect
-            v-if="
-              column.type === MoreTableFieldType.multiselect ||
-              column.type === MoreTableFieldType.singleselect
-            "
-            v-model="data[field]"
-            :options="getColumnEditableValues(column.editable)"
-            option-label="label"
-            option-value="value"
-            :selection-limit="
-              column.type === MoreTableFieldType.singleselect ? 1 : undefined
-            "
-            :placeholder="
-              column.placeholder ??
-              $t('global.placeholder.chooseDropdownOptionDefault')
-            "
-            :show-toggle-all="false"
-            class="z-top custom-multiselect-root"
-            :panel-class="'custom-multiselect-panel'"
-          >
-            <template #value="{ value }">
-              <span v-if="MoreTableFieldType.multiselect && value?.length >= 2">
-                {{ value.length }} {{ $t('global.placeholder.selected') }}
-              </span>
-              <span
-                v-else-if="
-                  (column.type === MoreTableFieldType.singleselect && value) ||
-                  (column.type === MoreTableFieldType.multiselect &&
-                    value?.length === 1)
-                "
-              >
-                {{
-                  value?.length
-                    ? getColumnEditableValues(column.editable)?.find((group: MoreTableChoice) => group.value === value[0])?.label
-                    : value
-                }}
-
-              </span>
-              <span
-                v-else-if="
-                  !value ||
-                  (MoreTableFieldType.multiselect && value.length === 0)
-                "
-                class="text-gray-400"
-              >
-                {{
-                  column.placeholder ??
-                  $t('global.placeholder.chooseDropdownOptionDefault')
-                }}
-              </span>
-              <span v-else>
-                {{ value }}
-              </span>
-            </template>
-          </MultiSelect>-->
           <div v-if="column.type === MoreTableFieldType.showIcon">
             <CustomCheckbox
               v-if="getObservationVisibility(data['type'])?.changeable"
@@ -643,34 +588,6 @@ Licensed under the Elastic License 2.0. */
               >{{ value }}</span
               >
             </span>
-
-            <!--
-            <span
-              v-if="
-                column.type === MoreTableFieldType.multiselect ||
-                column.type === MoreTableFieldType.singleselect
-              "
-            >
-              <span
-                v-if="
-                  (MoreTableFieldType.singleselect && !data[field]) ||
-                  (MoreTableFieldType.multiselect && !data[field]) ||
-                  (MoreTableFieldType.multiselect && data[field]?.length === 0)
-                "
-                class="text-gray-400"
-              >
-                {{ column.placeholder ?? $t('global.placeholder.chooseDropdownOptionDefault') }}
-              </span>
-              <span
-                v-for="(value, index) in getLabelForMultiSelectValue(
-                  data[field],
-                  getColumnEditableValues(column.editable)
-                )"
-                :key="index"
-                class="multiselect-item"
-                >{{ value }}</span
-              >
-            </span>-->
             <span
               v-if="column.type === MoreTableFieldType.showIcon"
               class="icon-box eye"

--- a/src/components/shared/MoreTable.vue
+++ b/src/components/shared/MoreTable.vue
@@ -30,12 +30,22 @@ Licensed under the Elastic License 2.0. */
   import CustomCheckbox from './CustomCheckbox.vue';
   import { FilterMatchMode } from 'primevue/api';
   import { dateToDateString } from '../../utils/dateUtils';
-  import { ComponentFactory, ParticipantStatus, StudyRole, StudyStatus, Visibility } from '@gs';
+  import {
+    ComponentFactory,
+    ParticipantStatus,
+    StudyRole,
+    StudyStatus,
+    Visibility,
+  } from '@gs';
   import { shortenText } from '../../utils/commonUtils';
   import { useGlobalStore } from '../../stores/globalStore';
   import ExclamationIcon from './ExclamationIcon.vue';
 
-  import { ACTION_ID_DATA_HEALTH, ACTION_ID_DELETE, ACTION_ID_QR_CODE } from '../../constants';
+  import {
+    ACTION_ID_DATA_HEALTH,
+    ACTION_ID_DELETE,
+    ACTION_ID_QR_CODE,
+  } from '../../constants';
 
   const dateFormat = useGlobalStore().getDateFormat;
 
@@ -268,32 +278,37 @@ Licensed under the Elastic License 2.0. */
   }
 
   function getActionBtnBgColor(actionId: string, data: any): string {
-    if (actionId === ACTION_ID_DELETE) return 'btn-important'
-    else if (actionId === ACTION_ID_DATA_HEALTH && data && data.dataHealthIndicator) {
+    if (actionId === ACTION_ID_DELETE) return 'btn-important';
+    else if (
+      actionId === ACTION_ID_DATA_HEALTH &&
+      data &&
+      data.dataHealthIndicator
+    ) {
       switch (data.dataHealthIndicator) {
         case 'green':
-          return 'btn-accepted'
+          return 'btn-accepted';
         case 'orange':
-          return 'btn-warn'
+          return 'btn-warn';
         case 'red':
-          return 'btn-important'
-        default: return 'btn-warn'
+          return 'btn-important';
+        default:
+          return 'btn-warn';
       }
     }
-    return ''
+    return '';
   }
 
   function getDataHealthIcon(data: any): string | undefined {
     if (data.dataHealthIndicator) {
-      switch(data.dataHealthIndicator) {
+      switch (data.dataHealthIndicator) {
         case 'green':
-          return 'pi pi-check'
+          return 'pi pi-check';
         case 'orange':
-          return 'pi pi-exclamation-triangle'
+          return 'pi pi-exclamation-triangle';
         case 'red':
-          return 'pi pi-times'
+          return 'pi pi-times';
         default:
-          return 'pi pi-exclamation-triangle'
+          return 'pi pi-exclamation-triangle';
       }
     }
   }
@@ -447,6 +462,7 @@ Licensed under the Elastic License 2.0. */
             v-model="data[field]"
             :options="getColumnEditableValues(column.editable)"
             option-label="label"
+            option-value="value"
             :selection-limit="
               column.type === MoreTableFieldType.singleselect ? 1 : undefined
             "
@@ -455,8 +471,45 @@ Licensed under the Elastic License 2.0. */
               $t('global.placeholder.chooseDropdownOptionDefault')
             "
             :show-toggle-all="false"
-            class="z-top"
-          />
+            class="z-top custom-multiselect-root"
+            :panel-class="'custom-multiselect-panel'"
+          >
+            <template #value="{ value }">
+              <span v-if="MoreTableFieldType.multiselect && value?.length >= 2">
+                {{ value.length }} {{ $t('global.placeholder.selected') }}
+              </span>
+              <span
+                v-else-if="
+                  (column.type === MoreTableFieldType.singleselect && value) ||
+                  (column.type === MoreTableFieldType.multiselect &&
+                    value?.length === 1)
+                "
+              >
+                {{
+                  value?.length
+                    ? getColumnEditableValues(column.editable).find(
+                        (group) => group.value === value[0],
+                      )?.label
+                    : value
+                }}
+              </span>
+              <span
+                v-else-if="
+                  !value ||
+                  (MoreTableFieldType.multiselect && value.length === 0)
+                "
+                class="text-gray-400"
+              >
+                {{
+                  column.placeholder ??
+                  $t('global.placeholder.chooseDropdownOptionDefault')
+                }}
+              </span>
+              <span v-else>
+                {{ value }}
+              </span>
+            </template>
+          </MultiSelect>
           <div v-if="column.type === MoreTableFieldType.showIcon">
             <CustomCheckbox
               v-if="getObservationVisibility(data['type'])?.changeable"
@@ -496,11 +549,14 @@ Licensed under the Elastic License 2.0. */
             {{ column.placeholder ?? $t('global.labels.noValue') }}
           </div>
           <div v-else>
-            <span v-if="field === 'title'" class="flex flex-row gap-1.5 align-center">
+            <span
+              v-if="field === 'title'"
+              class="align-center flex flex-row gap-1.5"
+            >
               <span v-if="data['hasError']" class="title-has-warning mr-0.2">
                 <ExclamationIcon id="exclamationIcon" />
               </span>
-              {{ data[field]}}
+              {{ data[field] }}
             </span>
             <span
               v-else-if="
@@ -554,6 +610,16 @@ Licensed under the Elastic License 2.0. */
               "
             >
               <span
+                v-if="
+                  (MoreTableFieldType.singleselect && !data[field]) ||
+                  (MoreTableFieldType.multiselect && !data[field]) ||
+                  (MoreTableFieldType.multiselect && data[field]?.length === 0)
+                "
+                class="text-gray-400"
+              >
+                {{ column.placeholder ?? $t('global.placeholder.chooseDropdownOptionDefault') }}
+              </span>
+              <span
                 v-for="(value, index) in getLabelForMultiSelectValue(
                   data[field],
                 )"
@@ -590,14 +656,23 @@ Licensed under the Elastic License 2.0. */
               <Button
                 v-tooltip.bottom="action.tooltip ?? undefined"
                 type="button"
-                :icon="action.id === ACTION_ID_DATA_HEALTH ? getDataHealthIcon(slotProps) ?? action.icon : action.icon"
+                :icon="
+                  action.id === ACTION_ID_DATA_HEALTH
+                    ? (getDataHealthIcon(slotProps) ?? action.icon)
+                    : action.icon
+                "
                 :disabled="
-                  action.id === ACTION_ID_DATA_HEALTH ? !slotProps.data?.dataHealthIndicator || slotProps.data?.dataHealthIndicator && slotProps.data.status === ParticipantStatus.New
-                  : rowIDsInEditMode.length
+                  action.id === ACTION_ID_DATA_HEALTH
+                    ? !slotProps.data?.dataHealthIndicator ||
+                      (slotProps.data?.dataHealthIndicator &&
+                        slotProps.data.status === ParticipantStatus.New)
+                    : rowIDsInEditMode.length
                       ? true
-                      : action.id === ACTION_ID_QR_CODE ?
-                        !(isVisible(action, slotProps.data) &&
-                        !!slotProps.data.registrationToken)
+                      : action.id === ACTION_ID_QR_CODE
+                        ? !(
+                            isVisible(action, slotProps.data) &&
+                            !!slotProps.data.registrationToken
+                          )
                         : !isVisible(action, slotProps.data)
                 "
                 :class="getActionBtnBgColor(action.id, slotProps.data)"
@@ -750,7 +825,8 @@ Licensed under the Elastic License 2.0. */
     padding: 5px;
   }
 
-  .title-has-warning, .title-has-warning #exclamationIcon {
+  .title-has-warning,
+  .title-has-warning #exclamationIcon {
     height: 18px;
     width: auto;
   }

--- a/src/components/shared/MoreTable.vue
+++ b/src/components/shared/MoreTable.vue
@@ -46,8 +46,10 @@ Licensed under the Elastic License 2.0. */
     ACTION_ID_DELETE,
     ACTION_ID_QR_CODE,
   } from '../../constants';
+  import { useI18n } from 'vue-i18n';
 
   const dateFormat = useGlobalStore().getDateFormat;
+  const { t } = useI18n();
 
   interface MoreTableProps {
     title?: string;
@@ -241,8 +243,12 @@ Licensed under the Elastic License 2.0. */
   function getLabelForMultiSelectValue(
     setValues: any,
     valueChoices?: MoreTableChoice[],
+    placeholder?: string
   ): string[] {
-    if (valueChoices) {
+    if (setValues?.length === 0) {
+      return placeholder ? [placeholder] : [t('global.placeholder.chooseDropdownOptionDefault')]
+    }
+    else if (valueChoices) {
       const labels: string[] = [];
       setValues.forEach((v: StudyRole) => {
         const valueLabel = valueChoices.find((vc) => vc.value === v);
@@ -462,6 +468,24 @@ Licensed under the Elastic License 2.0. */
             v-model="data[field]"
             :options="getColumnEditableValues(column.editable)"
             option-label="label"
+            :selection-limit="
+              column.type === MoreTableFieldType.singleselect ? 1 : undefined
+            "
+            :placeholder="
+              column.placeholder ??
+              $t('global.placeholder.chooseDropdownOptionDefault')
+            "
+            :show-toggle-all="false"
+            class="z-top"
+          />
+          <!--<MultiSelect
+            v-if="
+              column.type === MoreTableFieldType.multiselect ||
+              column.type === MoreTableFieldType.singleselect
+            "
+            v-model="data[field]"
+            :options="getColumnEditableValues(column.editable)"
+            option-label="label"
             option-value="value"
             :selection-limit="
               column.type === MoreTableFieldType.singleselect ? 1 : undefined
@@ -508,7 +532,7 @@ Licensed under the Elastic License 2.0. */
                 {{ value }}
               </span>
             </template>
-          </MultiSelect>
+          </MultiSelect>-->
           <div v-if="column.type === MoreTableFieldType.showIcon">
             <CustomCheckbox
               v-if="getObservationVisibility(data['type'])?.changeable"
@@ -602,6 +626,25 @@ Licensed under the Elastic License 2.0. */
             <span v-if="column.type === MoreTableFieldType.longtext"
               >{{ shortenText(data[field]) }}
             </span>
+
+            <span
+              v-if="
+                column.type === MoreTableFieldType.multiselect ||
+                column.type === MoreTableFieldType.singleselect
+              "
+            >
+              <span
+                v-for="(value, index) in getLabelForMultiSelectValue(
+                  data[field]
+                )"
+                :key="index"
+                class="multiselect-item"
+                :class="{'text-gray-300': MoreTableFieldType.multiselect && data[field]?.length === 0}"
+              >{{ value }}</span
+              >
+            </span>
+
+            <!--
             <span
               v-if="
                 column.type === MoreTableFieldType.multiselect ||
@@ -627,7 +670,7 @@ Licensed under the Elastic License 2.0. */
                 class="multiselect-item"
                 >{{ value }}</span
               >
-            </span>
+            </span>-->
             <span
               v-if="column.type === MoreTableFieldType.showIcon"
               class="icon-box eye"

--- a/src/components/shared/MoreTable.vue
+++ b/src/components/shared/MoreTable.vue
@@ -487,11 +487,10 @@ Licensed under the Elastic License 2.0. */
               >
                 {{
                   value?.length
-                    ? getColumnEditableValues(column.editable).find(
-                        (group) => group.value === value[0],
-                      )?.label
+                    ? getColumnEditableValues(column.editable)?.find((group: MoreTableChoice) => group.value === value[0])?.label
                     : value
                 }}
+
               </span>
               <span
                 v-else-if="
@@ -622,6 +621,7 @@ Licensed under the Elastic License 2.0. */
               <span
                 v-for="(value, index) in getLabelForMultiSelectValue(
                   data[field],
+                  getColumnEditableValues(column.editable)
                 )"
                 :key="index"
                 class="multiselect-item"

--- a/src/composable/useApi.ts
+++ b/src/composable/useApi.ts
@@ -21,7 +21,8 @@ import {
   ConfigurationApi,
   CalendarApi,
   AuditLogApi,
-  OccurredObservationsApi
+  OccurredObservationsApi,
+  ObservationGroupsApi
 } from '@gs';
 
 const apiConfig = {
@@ -45,6 +46,7 @@ let dataApi: DataApi;
 let uiConfigApi: ConfigurationApi;
 let auditLogApi: AuditLogApi;
 let occurredObservationsApi: OccurredObservationsApi;
+let observationGroupsApi: ObservationGroupsApi;
 
 export function useStudiesApi(): {
   studiesApi: StudiesApi;
@@ -169,5 +171,14 @@ export function useOccurredObservationsApi(): {
   occurredObservationsApi = occurredObservationsApi || new OccurredObservationsApi(apiConfig);
   return {
     occurredObservationsApi,
+  };
+}
+
+export function useObservationGroupsApi(): {
+  observationGroupsApi: ObservationGroupsApi;
+} {
+  observationGroupsApi = observationGroupsApi || new ObservationGroupsApi(apiConfig);
+  return {
+    observationGroupsApi,
   };
 }

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -861,7 +861,8 @@
         "durationExample": "Studienbeginn: {egStartDate} - Studienende: {egEndDate} (5 Monate) - Studiendauer: 4 Wochen. Die aktive Teilnahmezeit des Teilnehmers an der Studie ist auf 4 Wochen begrenzt. Dies wird durch das Login-Datum bestimmt.",
         "participantInfo": "Die Teilnehmerinformation wird in der App den Teilnehmer:innen angezeigt. Sie soll eine kurze Beschreibung über die Studie und ihren Aufgaben enthalten. Es enthält auch die Nutzungsbedingungen und die Datenschutzrichtlinie der Organisation, die die Studie durchführt.",
         "purpose": "Die Zielsetzung gibt Informationen über die Studie. Diese Information ist nur den Studien-Mitarbeitern zugänglich.",
-        "study": "Fügen Sie eine Beschreibung der Studie hinzu, die Ihren Studienmitarbeitern als Erkärung angezeigt wird."
+        "study": "Fügen Sie eine Beschreibung der Studie hinzu, die Ihren Studienmitarbeitern als Erkärung angezeigt wird.",
+        "howToCreateGroups": "Studien- und Datenerhebungsgruppen können über den Reiter Studie erstellen. Erstellte Studien- und/oder Datenerhebungsgruppen können hier für {for} zugewiesen werden."
       },
       "error": {
         "missedFieldsMsg": "Bitte füllen sie folgende Informationsfelder aus: "
@@ -881,7 +882,8 @@
         "institute": "Institut",
         "studyEnd": "Studienende",
         "studyStart": "Studienstart",
-        "studyTitle": "Studientitel"
+        "studyTitle": "Studientitel",
+        "chooseGroups": "Gruppen zuweisen"
       },
       "msg": {
         "delete": "Eine gelöschte Studie kann nicht wiederhergestellt werden. Möchten Sie die Studie wirklich löschen?",
@@ -938,6 +940,7 @@
       "roles": "Rolle(n)",
       "status": "Status",
       "studyGroup": "Studiengruppe {size}",
+      "groups": "Gruppen",
       "observationGroup": "Datenerhebungs-Gruppe {size}",
       "studyId": "Studien-ID",
       "title": "Titel"

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -862,7 +862,7 @@
         "participantInfo": "Die Teilnehmerinformation wird in der App den Teilnehmer:innen angezeigt. Sie soll eine kurze Beschreibung über die Studie und ihren Aufgaben enthalten. Es enthält auch die Nutzungsbedingungen und die Datenschutzrichtlinie der Organisation, die die Studie durchführt.",
         "purpose": "Die Zielsetzung gibt Informationen über die Studie. Diese Information ist nur den Studien-Mitarbeitern zugänglich.",
         "study": "Fügen Sie eine Beschreibung der Studie hinzu, die Ihren Studienmitarbeitern als Erkärung angezeigt wird.",
-        "howToCreateGroups": "Studien- und Datenerhebungsgruppen können über den Reiter Studie erstellet und für {for} zugewiesen werden."
+        "howToCreateGroups": "Studien- und Datenerhebungsgruppen können über den Reiter Studie erstellt und für {for} zugewiesen werden."
       },
       "error": {
         "missedFieldsMsg": "Bitte füllen sie folgende Informationsfelder aus: "

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -862,7 +862,7 @@
         "participantInfo": "Die Teilnehmerinformation wird in der App den Teilnehmer:innen angezeigt. Sie soll eine kurze Beschreibung über die Studie und ihren Aufgaben enthalten. Es enthält auch die Nutzungsbedingungen und die Datenschutzrichtlinie der Organisation, die die Studie durchführt.",
         "purpose": "Die Zielsetzung gibt Informationen über die Studie. Diese Information ist nur den Studien-Mitarbeitern zugänglich.",
         "study": "Fügen Sie eine Beschreibung der Studie hinzu, die Ihren Studienmitarbeitern als Erkärung angezeigt wird.",
-        "howToCreateGroups": "Studien- und Datenerhebungsgruppen können über den Reiter Studie erstellen. Erstellte Studien- und/oder Datenerhebungsgruppen können hier für {for} zugewiesen werden."
+        "howToCreateGroups": "Studien- und Datenerhebungsgruppen können über den Reiter Studie erstellet und für {for} zugewiesen werden."
       },
       "error": {
         "missedFieldsMsg": "Bitte füllen sie folgende Informationsfelder aus: "

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -937,6 +937,7 @@
       "roles": "Rolle(n)",
       "status": "Status",
       "studyGroup": "Studiengruppe {size}",
+      "observationGroup": "Datenerhebungs-Gruppe {size}",
       "studyId": "Studien-ID",
       "title": "Titel"
     },
@@ -1077,6 +1078,29 @@
       "searchCollaborators": "Tippen, um einen Studien-Mitarbeiter zu suchen."
     }
   },
+  "observationGroup": {
+    "dialog": {
+      "deleteMsg": {
+        "confirm": "Möchten Sie die Datenerhebungs-Gruppe wirklich löschen?",
+        "intro": "Sie sind kurz davor folgende Datenerhebungs-Gruppe zu löschen:",
+        "warning": "Eine gelöschte Datenerhebungs-Gruppe kann nicht wiederhergestellt werden. Jegliche Informationen und Einstellungen der Gruppe werden gelöscht. Alle Teilnehmer:innen, Datenerhebungsmodelle und Interventionen, die zu dieser Gruppe verlinkt waren, verlieren ihre Gruppenverlinkung und wirken wieder auf die gesamte Studie."
+      },
+      "header": {
+        "create": "Datenerhebungs-Gruppe hinzufügen",
+        "delete": "Datenerhebungs-Gruppe löschen"
+      },
+      "msg": {
+        "delete": "Möchten Sie die Datenerhebungs-Gruppe wirklich löschen?"
+      }
+    },
+    "plural": "Datenerhebungs-Gruppen",
+    "groupList": {
+      "description": "Datenerhebungs-Gruppen werden verwendet, um Teilnehmer:innen, Datenerhebungen und/oder Interventions zu gruppieren. Im Gegensatz zu den Studiengruppen, können diese multiplen Elementen zugewiesen werden. <b>Ein:e Teilnehmer:in, eine Datenerhebung und eine Intervention kann jeweils mehreren Datenerhebungs-Gruppen zugewiesen werden.</b> (Beisipel: Raucher, Diabetes Typ 2).",
+      "placeholder": {
+        "emptyGroupList": "Fügen Sie Datenerhebungs-Gruppen zu Ihrer Studie hinzu."
+      }
+    }
+  },
   "studyGroup": {
     "dialog": {
       "deleteMsg": {
@@ -1162,6 +1186,7 @@
       "deleteParticipantBtn": "Teilnehmer:in löschen",
       "deleteStudyBtn": "Studie löschen",
       "deleteStudyGroupBtn": "Studiengruppe löschen",
+      "deleteObservationGroupBtn": "Datenerhebungs-Gruppe löschen",
       "editBtn": "Bearbeiten Sie die gezeigten Eckdaten.",
       "goToStudy": "Studie öffnen",
       "saveChanges": "Änderungen speichern",

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -137,7 +137,8 @@
       "entireStudy": "Gesamte Studie",
       "noGroup": "Keine Gruppe",
       "nothingSelected": "Nichts ausgewählt",
-      "optionsSelected": "Optionen ausgewählt"
+      "optionsSelected": "Optionen ausgewählt",
+      "selected": "ausgewählt"
     }
   },
   "inputModel": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -861,7 +861,8 @@
         "durationExample": "Study Start; {egStartDate} - Study End: {egEndDate} (5 months) - Study Duration: 4 weeks. The participant's active participation time for the study is limited to 4 weeks, determined by their login date.",
         "participantInfo": "The participant information will be displayed on the app as the studies description. It should give a short information about the study and its purpose. It also includes the Terms of Service and Privacy Policy of the organization conducting the study.",
         "purpose": "The purpose property describes the general purpose of the study. This information will only be shown to study collaborators on the study configurator.",
-        "study": "Enter the base information of your study to provide basic information for collaborators and participants."
+        "study": "Enter the base information of your study to provide basic information for collaborators and participants.",
+        "howToCreateGroups": "Study and observation groups can be created on the Study tab. Created study and/or observation groups can then be assigned here for {for}."
       },
       "error": {
         "missedFieldsMsg": "Please fill out the following information fields: "
@@ -881,7 +882,8 @@
         "institute": "Institute",
         "studyEnd": "Study end",
         "studyStart": "Study start",
-        "studyTitle": "Study title"
+        "studyTitle": "Study title",
+        "chooseGroups": "Assign groups"
       },
       "msg": {
         "delete": "A deleted study can't be restored. Are you sure you want to delete your study?",
@@ -1094,7 +1096,7 @@
         "delete": "Do you really want to delete this observation group?"
       }
     },
-    "plural": "Datenerhebungs-Gruppen",
+    "plural": "Observation groups",
     "groupList": {
       "description": "Observation groups are used to group participants, observations, and/or interventions. Unlike study groups, they can be assigned to multiple elements. <b>A participant, an observation, and an intervention can each be assigned to multiple observation groups.</b> (Example: smokers, type 2 diabetes).",
       "placeholder": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -937,6 +937,7 @@
       "roles": "Role(s)",
       "status": "Status",
       "studyGroup": "Study group {size}",
+      "observationGroup": "Observation group {size}",
       "studyId": "Study ID",
       "title": "Title"
     },
@@ -1077,6 +1078,29 @@
       "searchCollaborators": "Type to search collaborators"
     }
   },
+  "observationGroup": {
+    "dialog": {
+      "deleteMsg": {
+        "confirm": "Are you sure you want to delete this observation group?",
+        "intro": "You are about to delete the following observation group:",
+        "warning": "A deleted observation group can't be restored. All information and settings of the observation group will be lost. The linked participants, interventions and observations will loose their group link and then apply to the entire study."
+      },
+      "header": {
+        "create": "Add observation group",
+        "delete": "Delete observation group"
+      },
+      "msg": {
+        "delete": "Do you really want to delete this observation group?"
+      }
+    },
+    "plural": "Datenerhebungs-Gruppen",
+    "groupList": {
+      "description": "Observation groups are used to group participants, observations, and/or interventions. Unlike study groups, they can be assigned to multiple elements. <b>A participant, an observation, and an intervention can each be assigned to multiple observation groups.</b> (Example: smokers, type 2 diabetes).",
+      "placeholder": {
+        "emptyGroupList": "Add observatoin groups to your study to use multi-group functionalities"
+      }
+    }
+  },
   "studyGroup": {
     "dialog": {
       "deleteMsg": {
@@ -1086,7 +1110,7 @@
       },
       "header": {
         "create": "Add study group",
-        "delete": "Delete group"
+        "delete": "Delete study group"
       },
       "msg": {
         "delete": "Do you really want to delete this study group?"
@@ -1162,6 +1186,7 @@
       "deleteParticipantBtn": "Delete participant",
       "deleteStudyBtn": "Delete study",
       "deleteStudyGroupBtn": "Delete study group",
+      "deleteObservationGroupBtn": "Delete observation group",
       "editBtn": "Edit shown properties.",
       "goToStudy": "Go to study",
       "saveChanges": "Save changes",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -137,7 +137,8 @@
       "entireStudy": "Entire study",
       "noGroup": "No group",
       "nothingSelected": "Nothing selected",
-      "optionsSelected": "options selected"
+      "optionsSelected": "options selected",
+      "selected": "selected"
     }
   },
   "inputModel": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -862,7 +862,7 @@
         "participantInfo": "The participant information will be displayed on the app as the studies description. It should give a short information about the study and its purpose. It also includes the Terms of Service and Privacy Policy of the organization conducting the study.",
         "purpose": "The purpose property describes the general purpose of the study. This information will only be shown to study collaborators on the study configurator.",
         "study": "Enter the base information of your study to provide basic information for collaborators and participants.",
-        "howToCreateGroups": "Study and observation groups can be created on the Study tab. Created study and/or observation groups can then be assigned here for {for}."
+        "howToCreateGroups": "Study and observation groups can be created on the study tab and assigned here for {for}."
       },
       "error": {
         "missedFieldsMsg": "Please fill out the following information fields: "

--- a/src/models/MoreTableModel.ts
+++ b/src/models/MoreTableModel.ts
@@ -70,6 +70,7 @@ export enum MoreTableFieldType {
   string,
   number,
   choice,
+  multipleChoice,
   calendar,
   multiselect,
   singleselect,
@@ -119,6 +120,18 @@ export interface MoreStudyGroupTableMap {
   numberOfParticipants?: number;
   created?: string;
   modified?: string;
+}
+
+export interface MoreParticipantListTableRow extends Participant {
+  observationGroupValues?: MoreTableChoice[]
+}
+
+export interface MoreInterventionListTableRow extends Intervention {
+  observationGroupValues?: MoreTableChoice[]
+}
+
+export interface MoreObservationListTableRow extends Observation {
+  observationGroupValues?: MoreTableChoice[]
 }
 
 export enum RowSelectionMode {

--- a/src/models/MoreTableModel.ts
+++ b/src/models/MoreTableModel.ts
@@ -123,15 +123,15 @@ export interface MoreStudyGroupTableMap {
 }
 
 export interface MoreParticipantListTableRow extends Participant {
-  observationGroupValues?: string[]
+  observationGroupValues?: MoreTableChoice[]
 }
 
 export interface MoreInterventionListTableRow extends Intervention {
-  observationGroupValues?: string[]
+  observationGroupValues?: MoreTableChoice[]
 }
 
 export interface MoreObservationListTableRow extends Observation {
-  observationGroupValues?: string[]
+  observationGroupValues?: MoreTableChoice[]
 }
 
 export enum RowSelectionMode {

--- a/src/models/MoreTableModel.ts
+++ b/src/models/MoreTableModel.ts
@@ -123,15 +123,15 @@ export interface MoreStudyGroupTableMap {
 }
 
 export interface MoreParticipantListTableRow extends Participant {
-  observationGroupValues?: MoreTableChoice[]
+  observationGroupValues?: string[]
 }
 
 export interface MoreInterventionListTableRow extends Intervention {
-  observationGroupValues?: MoreTableChoice[]
+  observationGroupValues?: string[]
 }
 
 export interface MoreObservationListTableRow extends Observation {
-  observationGroupValues?: MoreTableChoice[]
+  observationGroupValues?: string[]
 }
 
 export enum RowSelectionMode {

--- a/src/stores/observationGroupStore.ts
+++ b/src/stores/observationGroupStore.ts
@@ -1,0 +1,122 @@
+/*
+ Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ for Digital Health and Prevention -- A research institute of the
+ Ludwig Boltzmann Gesellschaft, Oesterreichische Vereinigung zur
+ Foerderung der wissenschaftlichen Forschung).
+ Licensed under the Elastic License 2.0.
+ */
+import { ref, Ref } from 'vue';
+import { defineStore } from 'pinia';
+import { ObservationGroup } from '@gs';
+import { useObservationGroupsApi } from '../composable/useApi';
+import i18n from '../i18n/i18n';
+import { useErrorHandling } from '../composable/useErrorHandling';
+import { AxiosError } from 'axios';
+
+export const useObservationGroupStore = defineStore('observationGroup', () => {
+  const { observationGroupsApi } = useObservationGroupsApi();
+  const { handleIndividualError } = useErrorHandling();
+
+  // State
+  const observationGroups: Ref<ObservationGroup[]> = ref([]);
+
+  // Actions
+  async function getObservationGroups(studyId: number): Promise<void> {
+    observationGroups.value = await observationGroupsApi
+      .listObservationGroups(studyId)
+      .then((response) => response.data)
+      .catch((e: AxiosError) => {
+        handleIndividualError(e, 'cannot list study group');
+        return observationGroups.value;
+      });
+  }
+  async function createObservationGroups(studyId: number): Promise<void> {
+    let title;
+    let count = observationGroups.value.length;
+    while (title === undefined) {
+      count += 1;
+      const _title = i18n.global.t('study.props.observationGroup', { size: count });
+      if (!observationGroups.value.find((g) => g.title === _title)) {
+        title = _title;
+      }
+    }
+    await observationGroupsApi
+      .createObservationGroup(studyId, {
+        studyId,
+        title,
+      })
+      .then((response) => observationGroups.value.push(response.data))
+      .catch((e: AxiosError) =>
+        handleIndividualError(e, 'cannot create study group'),
+      );
+  }
+
+  async function getObservationGroup(studyId: number, observationGroupId: number): Promise<void> {
+    const position = observationGroups.value.findIndex(
+      (observationGroupItem) =>
+        observationGroupItem.observationGroupId === observationGroupId,
+    );
+    await observationGroupsApi
+      .getObservationGroup(studyId, observationGroupId)
+      .then((response) => {
+        const observationGroup = response.data
+        observationGroups.value.splice(position, 1, observationGroup)
+      })
+      .catch((e: AxiosError) => {
+        handleIndividualError(e, 'cannot list study group');
+      })
+      .finally(() => {
+        return observationGroups.value;
+      });
+  }
+
+  async function updateObservationGroup(studyid: number, observationGroup: ObservationGroup): Promise<void> {
+    const position = observationGroups.value.findIndex(
+      (observationGroupItem) =>
+        observationGroupItem.observationGroupId === observationGroup.observationGroupId,
+    );
+    if (position > -1) {
+      await observationGroupsApi
+        .updateObservationGroup(
+          observationGroup.studyId as number,
+          observationGroup.observationGroupId as number,
+          observationGroup,
+        )
+        .then(() => observationGroups.value.splice(position, 1, observationGroup))
+        .catch((e: AxiosError) =>
+          handleIndividualError(e, 'cannot update study group'),
+        );
+    }
+  }
+
+  function deleteObservationGroup(observationGroup: ObservationGroup): void {
+    observationGroupsApi
+      .deleteObservationGroup(
+        observationGroup.studyId as number,
+        observationGroup.observationGroupId as number,
+      )
+      .then(() => {
+        const position = observationGroups.value.findIndex(
+          (studyGroupItem) =>
+            studyGroupItem.observationGroupId === observationGroup.observationGroupId &&
+            studyGroupItem.studyId === observationGroup.studyId,
+        );
+        observationGroups.value.splice(position, 1);
+      })
+      .catch((e: AxiosError) =>
+        handleIndividualError(e, 'cannot delete study group'),
+      );
+  }
+
+  return {
+    observationGroups,
+    createObservationGroups,
+    getObservationGroups,
+    updateObservationGroup,
+    getObservationGroup,
+    deleteObservationGroup,
+    //studyGroupMap,
+    //toStudyGroup,
+  };
+});

--- a/src/stores/observationGroupStore.ts
+++ b/src/stores/observationGroupStore.ts
@@ -115,8 +115,6 @@ export const useObservationGroupStore = defineStore('observationGroup', () => {
     getObservationGroups,
     updateObservationGroup,
     getObservationGroup,
-    deleteObservationGroup,
-    //studyGroupMap,
-    //toStudyGroup,
+    deleteObservationGroup
   };
 });

--- a/src/stores/studyStore.ts
+++ b/src/stores/studyStore.ts
@@ -136,7 +136,7 @@ export const useStudyStore = defineStore('study', () => {
       );
   }
 
-  async function listParticipantObservationsInTimeline(studyId: number, participantId: number, studyGroup?: number, referenceDate?: string, studyStartDate?: string, studyEndDate?: string): Promise<void> {
+  async function listParticipantObservationsInTimeline(studyId: number, participantId: number, studyGroup?: number, referenceDate?: number, studyStartDate?: string, studyEndDate?: string): Promise<void> {
     await calendarApi.getStudyTimeline(
       studyId,
       participantId,

--- a/src/stores/studyStore.ts
+++ b/src/stores/studyStore.ts
@@ -13,6 +13,7 @@ import { useAuditLogApi, useCalendarApi, useImportExportApi, useStudiesApi, useO
 import { AxiosError, AxiosResponse } from 'axios';
 import { useErrorHandling } from '../composable/useErrorHandling';
 import { useStudyGroupStore } from './studyGroupStore';
+import { useObservationGroupStore } from './observationGroupStore';
 import { DownloadData } from '../models/DataDownloadModel';
 import { useToastService } from '../composable/toastService';
 
@@ -24,6 +25,7 @@ export const useStudyStore = defineStore('study', () => {
   const { occurredObservationsApi } = useOccurredObservationsApi();
   const { handleIndividualError } = useErrorHandling();
   const studyGroupStore = useStudyGroupStore();
+  const observationGroupStore = useObservationGroupStore();
   const { handleToastErrors } = useToastService();
   // State
   const study: Ref<Study> = ref({});
@@ -37,7 +39,11 @@ export const useStudyStore = defineStore('study', () => {
   async function getStudy(studyId: number): Promise<void> {
     study.value = await studiesApi
       .getStudy(studyId)
-      .then((response) => response.data)
+      .then((response) => {
+        if (response.data?.studyId)
+          observationGroupStore.getObservationGroups(response.data.studyId)
+        return response.data
+      })
       .catch((e: AxiosError) => {
         handleIndividualError(e, 'cannot fetch study');
         return study.value;
@@ -82,6 +88,7 @@ export const useStudyStore = defineStore('study', () => {
       .then((response) => {
         studies.value.push(response.data);
         studyGroupStore.studyGroups = [];
+        observationGroupStore.observationGroups = [];
       })
       .catch((e: AxiosError) =>
         handleIndividualError(e, 'cannot create study'),
@@ -136,11 +143,12 @@ export const useStudyStore = defineStore('study', () => {
       );
   }
 
-  async function listParticipantObservationsInTimeline(studyId: number, participantId: number, studyGroup?: number, referenceDate?: number, studyStartDate?: string, studyEndDate?: string): Promise<void> {
+  async function listParticipantObservationsInTimeline(studyId: number, participantId: number, studyGroup?: number, observationGroup?: number, referenceDate?: string, studyStartDate?: string, studyEndDate?: string): Promise<void> {
     await calendarApi.getStudyTimeline(
       studyId,
       participantId,
       studyGroup,
+      observationGroup,
       referenceDate,
       studyStartDate,
       studyEndDate,

--- a/src/views/Interventions.vue
+++ b/src/views/Interventions.vue
@@ -10,9 +10,11 @@ Licensed under the Elastic License 2.0. */
   import InterventionsList from '../components/InterventionsList.vue';
   import { useStudyStore } from '../stores/studyStore';
   import { useStudyGroupStore } from '../stores/studyGroupStore';
+  import { useObservationGroupStore } from '../stores/observationGroupStore';
 
   const studyStore = useStudyStore();
   const studyGroupStore = useStudyGroupStore();
+  const observationGroupStore = useObservationGroupStore();
 
   const accessRoles: StudyRole[] = [
     StudyRole.StudyAdmin,
@@ -36,6 +38,7 @@ Licensed under the Elastic License 2.0. */
           :study-groups="studyGroupStore.studyGroups"
           :study-id="studyStore.studyId"
           :study-status="studyStore.studyStatus"
+          :observation-groups="observationGroupStore.observationGroups"
         />
       </Suspense>
     </div>

--- a/src/views/Observations.vue
+++ b/src/views/Observations.vue
@@ -10,9 +10,11 @@ Licensed under the Elastic License 2.0. */
   import ObservationList from '../components/ObservationList.vue';
   import { useStudyStore } from '../stores/studyStore';
   import { useStudyGroupStore } from '../stores/studyGroupStore';
+  import { useObservationGroupStore } from '../stores/observationGroupStore';
 
   const studyStore = useStudyStore();
   const studyGroupStore = useStudyGroupStore();
+  const observationGroupStore = useObservationGroupStore();
 
   const accessRoles: StudyRole[] = [
     StudyRole.StudyAdmin,
@@ -40,6 +42,7 @@ Licensed under the Elastic License 2.0. */
           :study-groups="studyGroupStore.studyGroups"
           :study-id="studyStore.studyId"
           :study-status="studyStore.studyStatus"
+          :observation-groups="observationGroupStore.observationGroups"
         />
       </Suspense>
     </div>

--- a/src/views/Participants.vue
+++ b/src/views/Participants.vue
@@ -10,13 +10,22 @@ Licensed under the Elastic License 2.0. */
   import { StudyRole } from '@gs';
   import { useStudyStore } from '../stores/studyStore';
   import { useStudyGroupStore } from '../stores/studyGroupStore';
+  import { useObservationGroupStore } from '../stores/observationGroupStore';
+  import { onMounted } from 'vue';
   const studyStore = useStudyStore();
   const studyGroupStore = useStudyGroupStore();
+  const observationGroupStore = useObservationGroupStore();
 
   const accessRoles: StudyRole[] = [
     StudyRole.StudyAdmin,
     StudyRole.StudyOperator,
   ];
+
+onMounted(() => {
+  if(observationGroupStore.observationGroups.length === 0) {
+    observationGroupStore.getObservationGroups(studyStore.studyId)
+  }
+})
 </script>
 
 <template>
@@ -32,6 +41,7 @@ Licensed under the Elastic License 2.0. */
     >
       <ParticipantList
         :study-groups="studyGroupStore.studyGroups"
+        :observation-groups="observationGroupStore.observationGroups"
         :study-status="studyStore.studyStatus"
         :study-id="studyStore.studyId"
       ></ParticipantList>

--- a/src/views/StudyOverview.vue
+++ b/src/views/StudyOverview.vue
@@ -15,11 +15,14 @@ Licensed under the Elastic License 2.0. */
   import { AxiosError } from 'axios';
   import { useToastService } from '../composable/toastService';
   import { StudyStatus } from '@gs';
+  import { useObservationGroupStore } from '../stores/observationGroupStore';
+  import ObservationGroupList from '../components/ObservationGroupList.vue';
 
   const { handleToastErrors } = useToastService();
   const route = useRoute();
   const studyStore = useStudyStore();
   const studyGroupStore = useStudyGroupStore();
+  const observationGroupStore = useObservationGroupStore();
   const studyId = parseInt(route.params.studyId as string);
 
   async function processUpdatedStudyStatus(status: StudyStatus): Promise<void> {
@@ -36,6 +39,7 @@ Licensed under the Elastic License 2.0. */
 
   studyStore.getStudy(studyId);
   studyGroupStore.getStudyGroups(studyId);
+  observationGroupStore.getObservationGroups(studyId)
 </script>
 
 <template>
@@ -52,6 +56,13 @@ Licensed under the Elastic License 2.0. */
       />
 
       <StudyGroupList
+        :study-id="studyId"
+        :user-roles="studyStore.studyUserRoles"
+        :study-status="studyStore.studyStatus"
+      />
+
+      <ObservationGroupList
+        class="mt-10"
         :study-id="studyId"
         :user-roles="studyStore.studyUserRoles"
         :study-status="studyStore.studyStatus"

--- a/src/views/StudyOverview.vue
+++ b/src/views/StudyOverview.vue
@@ -39,7 +39,7 @@ Licensed under the Elastic License 2.0. */
 
   studyStore.getStudy(studyId);
   studyGroupStore.getStudyGroups(studyId);
-  observationGroupStore.getObservationGroups(studyId)
+  observationGroupStore.getObservationGroups(studyId);
 </script>
 
 <template>


### PR DESCRIPTION
Ticket: https://github.com/redlink-gmbh/umm-project/issues/252

#252: implement extension for observation groups
- add StudyManagerApi.yaml extension
- implement observationGroup store
- add a observationGroupList to Study Overview
- extend ParticipantList.vue, InterventionsList.vue and ObservationList.vue with observation group selection
- extend InterventionDialog.vue and ObservationDialog.vue with observation group selection
- fix preview of MultiSelect Preview label

Bug found with the multiselect (similar to single select)