### PR TITLE
#271 (former #252): Timeline fix & Export Download

### DIFF
--- a/openapi/StudyManagerAPI.yaml
+++ b/openapi/StudyManagerAPI.yaml
@@ -1293,6 +1293,12 @@ paths:
             type: array
             items:
               type: integer
+        - name: observationGroupId
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
         - name: participantId
           in: query
           schema:
@@ -1901,6 +1907,9 @@ components:
         hidden:
           type: boolean
         noSchedule:
+          type: boolean
+          default: false
+        reminder:
           type: boolean
           default: false
         observationGroupIds:

--- a/src/components/ParticipationDataList.vue
+++ b/src/components/ParticipationDataList.vue
@@ -45,6 +45,7 @@ Licensed under the Elastic License 2.0. */
   import { useGlobalStore } from '../stores/globalStore';
   import { DropdownOption } from '../models/Common';
   import { useStudyGroupStore } from '../stores/studyGroupStore';
+  import { useObservationGroupStore } from '../stores/observationGroupStore';
   import useLoader from '../composable/useLoader';
   import { ComponentFactory, Participant } from '@gs/models';
 
@@ -57,6 +58,7 @@ Licensed under the Elastic License 2.0. */
   const dateFormat = useGlobalStore().getDateFormat;
   const studyStore = useStudyStore();
   const studyGroupStore = useStudyGroupStore();
+  const observationGroupStore = useObservationGroupStore();
 
   const props = defineProps({
     studyId: {
@@ -97,6 +99,23 @@ Licensed under the Elastic License 2.0. */
         ({
           label: studyGroup.title,
           value: studyGroup.studyGroupId?.toString(),
+        }) as DropdownOption,
+    ),
+  );
+
+  const observationGroupOptions: Ref<DropdownOption[]> = ref([
+    {
+      label: t('global.placeholder.entireStudy'),
+      value: undefined,
+    } as DropdownOption,
+  ]);
+
+  observationGroupOptions.value.push(
+    ...observationGroupStore.observationGroups.map(
+      (observationGroup) =>
+        ({
+          label: observationGroup.title,
+          value: observationGroup.observationGroupId?.toString(),
         }) as DropdownOption,
     ),
   );

--- a/src/components/ParticipationDataList.vue
+++ b/src/components/ParticipationDataList.vue
@@ -45,7 +45,6 @@ Licensed under the Elastic License 2.0. */
   import { useGlobalStore } from '../stores/globalStore';
   import { DropdownOption } from '../models/Common';
   import { useStudyGroupStore } from '../stores/studyGroupStore';
-  import { useObservationGroupStore } from '../stores/observationGroupStore';
   import useLoader from '../composable/useLoader';
   import { ComponentFactory, Participant } from '@gs/models';
 
@@ -58,7 +57,6 @@ Licensed under the Elastic License 2.0. */
   const dateFormat = useGlobalStore().getDateFormat;
   const studyStore = useStudyStore();
   const studyGroupStore = useStudyGroupStore();
-  const observationGroupStore = useObservationGroupStore();
 
   const props = defineProps({
     studyId: {
@@ -99,23 +97,6 @@ Licensed under the Elastic License 2.0. */
         ({
           label: studyGroup.title,
           value: studyGroup.studyGroupId?.toString(),
-        }) as DropdownOption,
-    ),
-  );
-
-  const observationGroupOptions: Ref<DropdownOption[]> = ref([
-    {
-      label: t('global.placeholder.entireStudy'),
-      value: undefined,
-    } as DropdownOption,
-  ]);
-
-  observationGroupOptions.value.push(
-    ...observationGroupStore.observationGroups.map(
-      (observationGroup) =>
-        ({
-          label: observationGroup.title,
-          value: observationGroup.observationGroupId?.toString(),
         }) as DropdownOption,
     ),
   );

--- a/src/components/TimelineList.vue
+++ b/src/components/TimelineList.vue
@@ -17,11 +17,11 @@ Licensed under the Elastic License 2.0. */
   import {
     ComponentFactory,
     InterventionTimelineEvent,
-    ListComponentsComponentTypeEnum,
+    ListComponentsComponentTypeEnum, ObservationGroup,
     ObservationTimelineEvent,
     Participant,
     StudyGroup,
-    StudyTimeline,
+    StudyTimeline
   } from '@gs';
   import { useStudyStore } from '../stores/studyStore';
   import {
@@ -48,11 +48,13 @@ Licensed under the Elastic License 2.0. */
   const props = defineProps({
     studyId: { type: Number, required: true },
     studyGroups: { type: Array as PropType<Array<StudyGroup>>, required: true },
+    observationGroups: { type: Array as PropType<Array<ObservationGroup>>, required: true }
   });
 
   const vueCalLocale = locale.value.split('-')[0];
   const filterRelativeStartDate = ref();
   const filterStudyGroup = ref();
+  const filterObservationGroup = ref();
   const filterParticipant = ref();
   const filterObservationAndIntervention = ref();
   const showFullTimeline = ref(false);
@@ -94,6 +96,23 @@ Licensed under the Elastic License 2.0. */
         ({
           label: studyGroup.title,
           value: studyGroup.studyGroupId?.toString(),
+        }) as DropdownOption,
+    ),
+  );
+
+  const observationGroupOptions: Ref<DropdownOption[]> = ref([
+    {
+      label: t('global.placeholder.entireStudy'),
+      value: undefined,
+    } as DropdownOption,
+  ]);
+
+  observationGroupOptions.value.push(
+    ...props.observationGroups.map(
+      (observationGroup) =>
+        ({
+          label: observationGroup.title,
+          value: observationGroup.observationGroupId?.toString(),
         }) as DropdownOption,
     ),
   );
@@ -276,41 +295,58 @@ Licensed under the Elastic License 2.0. */
     return translation;
   }
 
-  function onStudyGroupFilterChange(e: DropdownChangeEvent): void {
-    const filteredOptions: DropdownOption[] = [];
-    const filteredParticipants: Participant[] = [];
+  type ParticipantGroupField = 'studyGroupId' | 'observationGroupId';
 
-    filteredOptions.push({
-      label: t('participants.placeholder.allParticipants'),
-      value: undefined,
-    } as DropdownOption);
+  function rebuildParticipantOptionsByGroup(
+    field: ParticipantGroupField,
+    selectedId?: string | undefined, // kommt aus Dropdown als string
+  ): void {
+    const id = selectedId ? parseInt(selectedId) : undefined;
 
-    if (e.value) {
-      filteredParticipants.push(
-        ...participantsList.filter(
-          (participant) => participant.studyGroupId === parseInt(e.value),
-        ),
-      );
-    } else {
-      filteredParticipants.push(...participantsList);
-    }
+    const filteredParticipants = id
+      ? participantsList.filter((p) => (p as any)[field] === id)
+      : participantsList;
 
-    filteredOptions.push(
+    participantOptions.value = [
+      {
+        label: t('participants.placeholder.allParticipants'),
+        value: undefined,
+      } as DropdownOption,
       ...filteredParticipants.map(
-        (filteredParticipant) =>
+        (p) =>
           ({
-            label: filteredParticipant.alias,
-            value: filteredParticipant.participantId?.toString(),
+            label: p.alias,
+            value: p.participantId?.toString(),
           }) as DropdownOption,
       ),
-    );
+    ];
 
-    participantOptions.value = filteredOptions;
-    listTimeline();
+    // reset falls ungültig
+    if (
+      filterParticipant.value &&
+      !filteredParticipants.some(
+        (p) => p.participantId?.toString() === filterParticipant.value,
+      )
+    ) {
+      filterParticipant.value = undefined;
+    }
   }
+
 
   function onParticipantFilterChange(e: DropdownChangeEvent): void {
     filterStudyGroup.value = getStudyGroupIdByParticipantId(parseInt(e.value));
+    listTimeline();
+  }
+
+  function onObservationGroupFilterChange(e: DropdownChangeEvent): void {
+    filterObservationGroup.value = e.value;
+    rebuildParticipantOptionsByGroup('observationGroupId', e.value);
+    listTimeline();
+  }
+
+  function onStudyGroupFilterChange(e: DropdownChangeEvent): void {
+    filterStudyGroup.value = e.value;
+    rebuildParticipantOptionsByGroup('studyGroupId', e.value);
     listTimeline();
   }
 
@@ -354,6 +390,7 @@ Licensed under the Elastic License 2.0. */
   function clearAllFilters(): void {
     filterRelativeStartDate.value = undefined;
     filterStudyGroup.value = undefined;
+    filterObservationGroup.value = undefined;
     filterParticipant.value = undefined;
     filterObservationAndIntervention.value = [];
     listTimeline();
@@ -422,6 +459,7 @@ Licensed under the Elastic License 2.0. */
         props.studyId,
         filterParticipant.value,
         filterStudyGroup.value,
+        filterObservationGroup.value,
         filterRelativeStartDate.value,
         studyStartDate,
         studyEndDate,
@@ -512,6 +550,18 @@ Licensed under the Elastic License 2.0. */
           class="ml-1"
           :disabled="filterParticipant !== undefined"
           @change="onStudyGroupFilterChange"
+        />
+      </div>
+      <div class="flex-row-center">
+        {{ $t('observationGroup.singular') }}:
+        <Dropdown
+          v-model="filterObservationGroup"
+          :options="observationGroupOptions"
+          option-label="label"
+          option-value="value"
+          :placeholder="$t('observationGroup.placeholder.chooseGroup')"
+          class="ml-1"
+          @change="onObservationGroupFilterChange"
         />
       </div>
       <div class="flex-row-center">

--- a/src/components/subComponents/DataDownload.vue
+++ b/src/components/subComponents/DataDownload.vue
@@ -1,7 +1,14 @@
 <script setup lang="ts">
   import Calendar from 'primevue/calendar';
   import Button from 'primevue/button';
-  import { computed, ComputedRef, onBeforeMount, onBeforeUnmount, Ref, ref } from 'vue';
+  import {
+    computed,
+    ComputedRef,
+    onBeforeMount,
+    onBeforeUnmount,
+    Ref,
+    ref,
+  } from 'vue';
   import { DropdownOption } from '../../models/Common';
   import { ComponentFactory, Observation, Participant } from '@gs';
   import { AxiosError, AxiosResponse } from 'axios';
@@ -141,15 +148,17 @@
     getObservationList();
   }
 
-  const isDownloadDataLoading = ref<boolean>(false)
+  const isDownloadDataLoading = ref<boolean>(false);
   function downloadStudyData(): void {
-    isDownloadDataLoading.value = true
-    studyStore.exportStudyData({
-      studyId: studyStore.studyId,
-      ...getDownloadFilters(),
-    }).then(() => {
-      isDownloadDataLoading.value = false
-    });
+    isDownloadDataLoading.value = true;
+    studyStore
+      .exportStudyData({
+        studyId: studyStore.studyId,
+        ...getDownloadFilters(),
+      })
+      .then(() => {
+        isDownloadDataLoading.value = false;
+      });
   }
 
   function getDownloadFilters(): DownloadDataFilter {
@@ -164,7 +173,7 @@
 
     if (filterDateRange.value && filterDateRange.value.length > 1) {
       filterValues.from = filterDateRange.value[0];
-      const toDate = filterDateRange.value[1];
+      const toDate = filterDateRange.value[1] ?? filterDateRange.value[0];
       toDate.setHours(23, 59, 59);
       filterValues.to = toDate;
     }
@@ -175,10 +184,6 @@
   const disableStudyGroupFilter: ComputedRef<boolean> = computed(() => {
     return filterParticipant.value.length > 0;
   });
-
-  const disableObservationGroupFilter: ComputedRef<boolean> = computed(() => {
-    return filterObservationGroup.value.length > 0;
-  })
 
   const disableParticipantFilter: ComputedRef<boolean> = computed(() => {
     return filterStudyGroup.value.length > 0;
@@ -201,7 +206,7 @@
       data: {
         message: t('monitoringData.dialog.msg.downloadStudyData'),
         cancelBtn: t('monitoringData.dialog.waitForDownload'),
-        approveBtn: t('monitoringData.dialog.navigatePage')
+        approveBtn: t('monitoringData.dialog.navigatePage'),
       },
       props: {
         header: t('monitoringData.dialog.header.downloadStudyData'),
@@ -215,40 +220,40 @@
         modal: true,
         draggable: false,
       },
-      onClose: (options) =>{
+      onClose: (options) => {
         if (options?.data) {
           if (pendingRoute.value) {
-            isDownloadDataLoading.value = false
-            router.push(pendingRoute.value)
+            isDownloadDataLoading.value = false;
+            router.push(pendingRoute.value);
           }
         }
-        pendingRoute.value = null
-      }
-    })
+        pendingRoute.value = null;
+      },
+    });
   }
 
   onBeforeRouteLeave((to, from, next) => {
     if (isDownloadDataLoading.value) {
-      pendingRoute.value = to
-      interceptPageNavigation()
+      pendingRoute.value = to;
+      interceptPageNavigation();
       // preventNavigation
-      next(false)
+      next(false);
     } else {
       // navigate
-      next()
+      next();
     }
-  })
+  });
 
   onBeforeMount(() => {
     window.addEventListener('beforeunload', (e) => {
-      if (isDownloadDataLoading.value) e.preventDefault() }
-    )
-  })
+      if (isDownloadDataLoading.value) e.preventDefault();
+    });
+  });
   onBeforeUnmount(() => {
     window.removeEventListener('beforeunload', (e) => {
-      if (isDownloadDataLoading.value) e.preventDefault() }
-    )
-  })
+      if (isDownloadDataLoading.value) e.preventDefault();
+    });
+  });
 </script>
 
 <template>
@@ -269,10 +274,12 @@
         @click="clearAllFilters"
       />
     </div>
-    <div class="mb-3 flex flex-row items-center justify-between gap-5 mt-2">
+    <div class="mb-3 mt-2 flex flex-row items-center justify-between gap-5">
       <div class="flex flex-col gap-3">
-        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-6 gap-2 lg:gap-5">
-          <div class="lg:col-span-2 flex flex-row items-center gap-2">
+        <div
+          class="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-6 lg:gap-5"
+        >
+          <div class="flex flex-row items-center gap-2 lg:col-span-2">
             {{ $t('monitoring.labels.dateRange') }}:
             <Calendar
               v-model="filterDateRange"
@@ -285,7 +292,7 @@
               class="w-full"
             />
           </div>
-          <div class="lg:col-span-2 flex flex-row items-center gap-2">
+          <div class="flex flex-row items-center gap-2 lg:col-span-2">
             {{ $t('participants.plural') }}:
             <MultiSelect
               v-model="filterParticipant"
@@ -299,11 +306,11 @@
               :empty-message="$t('global.labels.noRecords')"
               :max-selected-labels="1"
               :selected-items-label="`{0} ${$t(
-              'global.placeholder.optionsSelected',
-            )}`"
+                'global.placeholder.optionsSelected',
+              )}`"
             />
           </div>
-          <div class="lg:col-span-2 flex flex-row items-center gap-2">
+          <div class="flex flex-row items-center gap-2 lg:col-span-2">
             {{ $t('observation.plural') }}:
             <MultiSelect
               v-model="filterObservation"
@@ -315,14 +322,16 @@
               :empty-message="$t('global.labels.noRecords')"
               :max-selected-labels="0"
               :selected-items-label="`{0} ${$t(
-              'global.placeholder.optionsSelected',
-            )}`"
+                'global.placeholder.optionsSelected',
+              )}`"
             ></MultiSelect>
           </div>
         </div>
-        <div class="flex flex-col lg:flex-row gap-3">
-          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-6 gap-2 lg:gap-5">
-            <div class="lg:col-span-2 flex flex-row items-center gap-2">
+        <div class="flex flex-col gap-3 lg:flex-row">
+          <div
+            class="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-6 lg:gap-5"
+          >
+            <div class="flex flex-row items-center gap-2 lg:col-span-2">
               {{ $t('studyGroup.plural') }}:
               <MultiSelect
                 v-model="filterStudyGroup"
@@ -339,8 +348,8 @@
                 )}`"
               />
             </div>
-            <div class="lg:col-span-2 flex flex-row items-center gap-2">
-              {{ $t('studyGroup.plural') }}:
+            <div class="flex flex-row items-center gap-2 lg:col-span-2">
+              {{ $t('observationGroup.plural') }}:
               <MultiSelect
                 v-model="filterObservationGroup"
                 :options="observationGroupOptions"
@@ -348,7 +357,6 @@
                 option-value="value"
                 :placeholder="$t('observationGroup.placeholder.chooseGroup')"
                 class="w-full"
-                :disabled="disableObservationGroupFilter"
                 :empty-message="$t('global.labels.noRecords')"
                 :max-selected-labels="1"
                 :selected-items-label="`{0} ${$t(
@@ -369,10 +377,10 @@
         @click="downloadStudyData()"
       >
         <span class="p-button-icon p-button-icon-left pi pi-download"></span>
-      <span>{{t('study.studyList.labels.exportStudyData')}}</span>
+        <span>{{ t('study.studyList.labels.exportStudyData') }}</span>
         <ProgressSpinner
           v-if="isDownloadDataLoading"
-          class="!text-white ml-2"
+          class="ml-2 !text-white"
           style="width: 25px; height: 25px"
           stroke-width="6"
           fill="transparent"
@@ -385,6 +393,6 @@
 
 <style scoped lang="postcss">
   :deep(.p-progress-spinner-circle) {
-    stroke: currentColor!important;
+    stroke: currentColor !important;
   }
 </style>

--- a/src/components/subComponents/DataDownload.vue
+++ b/src/components/subComponents/DataDownload.vue
@@ -21,6 +21,7 @@
   import { useDialog } from 'primevue/usedialog';
   import ConfirmationDialog from '../dialog/ConfirmationDialog.vue';
   import { onBeforeRouteLeave, useRouter } from 'vue-router';
+  import { useObservationGroupStore } from '../../stores/observationGroupStore';
 
   const dialog = useDialog();
   const router = useRouter();
@@ -34,12 +35,14 @@
   const { participantsApi } = useParticipantsApi();
   const studyGroupStore = useStudyGroupStore();
   const studyStore = useStudyStore();
+  const observationGroupStore = useObservationGroupStore();
 
   const observationList: Ref<Observation[]> = ref([]);
   let factories: ComponentFactory[] = await getFactories();
   const filterDateRange = ref();
 
   const filterStudyGroup = ref([]);
+  const filterObservationGroup = ref([]);
   const filterParticipant = ref([]);
   const filterObservation = ref([]);
   const observationOptions: ComputedRef<DropdownOption[]> = computed(() => {
@@ -67,6 +70,18 @@
     ),
   );
 
+  const observationGroupOptions: Ref<DropdownOption[]> = ref([]);
+
+  observationGroupOptions.value.push(
+    ...observationGroupStore.observationGroups.map(
+      (observationGroup) =>
+        ({
+          label: observationGroup.title,
+          value: observationGroup.observationGroupId?.toString(),
+        }) as DropdownOption,
+    ),
+  );
+
   let participantsList: Participant[] = [];
   const participantOptions: Ref<DropdownOption[]> = ref([]);
 
@@ -74,6 +89,7 @@
     filterParticipant.value = [];
     filterObservation.value = [];
     filterStudyGroup.value = [];
+    filterObservationGroup.value = [];
     filterDateRange.value = undefined;
   }
 
@@ -82,6 +98,7 @@
       filterParticipant.value.length > 0 ||
       filterObservation.value.length > 0 ||
       filterStudyGroup.value.length > 0 ||
+      filterObservationGroup.value.length > 0 ||
       filterDateRange.value !== undefined
     );
   });
@@ -140,6 +157,7 @@
       studyGroupId: filterStudyGroup.value ?? undefined,
       participantId: filterParticipant.value ?? undefined,
       observationId: filterObservation.value ?? undefined,
+      observationGroupId: filterObservationGroup.value ?? undefined,
       from: undefined,
       to: undefined,
     };
@@ -157,6 +175,10 @@
   const disableStudyGroupFilter: ComputedRef<boolean> = computed(() => {
     return filterParticipant.value.length > 0;
   });
+
+  const disableObservationGroupFilter: ComputedRef<boolean> = computed(() => {
+    return filterObservationGroup.value.length > 0;
+  })
 
   const disableParticipantFilter: ComputedRef<boolean> = computed(() => {
     return filterStudyGroup.value.length > 0;
@@ -247,70 +269,94 @@
         @click="clearAllFilters"
       />
     </div>
-    <div class="mb-3 flex flex-row items-center justify-between gap-5">
-      <div class="flex gap-5">
-        <div class="flex flex-row items-center">
-          {{ $t('monitoring.labels.dateRange') }}:
-          <Calendar
-            v-model="filterDateRange"
-            :min-date="new Date(studyStore.study.plannedStart as string)"
-            autocomplete="off"
-            selection-mode="range"
-            :manual-input="false"
-            :date-format="dateFormat"
-            :placeholder="`${dateFormat} - ${dateFormat}`"
-          />
-        </div>
-        <div class="flex flex-row items-center">
-          {{ $t('studyGroup.plural') }}:
-          <MultiSelect
-            v-model="filterStudyGroup"
-            :options="studyGroupOptions"
-            option-label="label"
-            option-value="value"
-            :placeholder="$t('studyGroup.placeholder.chooseGroup')"
-            class="ml-1"
-            :disabled="disableStudyGroupFilter"
-            :empty-message="$t('global.labels.noRecords')"
-            :max-selected-labels="1"
-            :selected-items-label="`{0} ${$t(
+    <div class="mb-3 flex flex-row items-center justify-between gap-5 mt-2">
+      <div class="flex flex-col gap-3">
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-6 gap-2 lg:gap-5">
+          <div class="lg:col-span-2 flex flex-row items-center gap-2">
+            {{ $t('monitoring.labels.dateRange') }}:
+            <Calendar
+              v-model="filterDateRange"
+              :min-date="new Date(studyStore.study.plannedStart as string)"
+              autocomplete="off"
+              selection-mode="range"
+              :manual-input="false"
+              :date-format="dateFormat"
+              :placeholder="`${dateFormat} - ${dateFormat}`"
+              class="w-full"
+            />
+          </div>
+          <div class="lg:col-span-2 flex flex-row items-center gap-2">
+            {{ $t('participants.plural') }}:
+            <MultiSelect
+              v-model="filterParticipant"
+              :options="participantOptions"
+              option-label="label"
+              option-value="value"
+              :placeholder="$t('participants.placeholder.chooseParticipant')"
+              class="w-full"
+              filter
+              :disabled="disableParticipantFilter"
+              :empty-message="$t('global.labels.noRecords')"
+              :max-selected-labels="1"
+              :selected-items-label="`{0} ${$t(
               'global.placeholder.optionsSelected',
             )}`"
-          />
-        </div>
-        <div class="flex flex-row items-center">
-          {{ $t('participants.plural') }}:
-          <MultiSelect
-            v-model="filterParticipant"
-            :options="participantOptions"
-            option-label="label"
-            option-value="value"
-            :placeholder="$t('participants.placeholder.chooseParticipant')"
-            class="ml-1"
-            filter
-            :disabled="disableParticipantFilter"
-            :empty-message="$t('global.labels.noRecords')"
-            :max-selected-labels="1"
-            :selected-items-label="`{0} ${$t(
+            />
+          </div>
+          <div class="lg:col-span-2 flex flex-row items-center gap-2">
+            {{ $t('observation.plural') }}:
+            <MultiSelect
+              v-model="filterObservation"
+              :options="observationOptions"
+              option-label="label"
+              option-value="value"
+              :placeholder="$t('timeline.labels.chooseType')"
+              class="w-full"
+              :empty-message="$t('global.labels.noRecords')"
+              :max-selected-labels="0"
+              :selected-items-label="`{0} ${$t(
               'global.placeholder.optionsSelected',
             )}`"
-          />
+            ></MultiSelect>
+          </div>
         </div>
-        <div class="flex flex-row items-center">
-          {{ $t('observation.plural') }}:
-          <MultiSelect
-            v-model="filterObservation"
-            :options="observationOptions"
-            option-label="label"
-            option-value="value"
-            :placeholder="$t('timeline.labels.chooseType')"
-            class="ml-1"
-            :empty-message="$t('global.labels.noRecords')"
-            :max-selected-labels="0"
-            :selected-items-label="`{0} ${$t(
-              'global.placeholder.optionsSelected',
-            )}`"
-          ></MultiSelect>
+        <div class="flex flex-col lg:flex-row gap-3">
+          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-6 gap-2 lg:gap-5">
+            <div class="lg:col-span-2 flex flex-row items-center gap-2">
+              {{ $t('studyGroup.plural') }}:
+              <MultiSelect
+                v-model="filterStudyGroup"
+                :options="studyGroupOptions"
+                option-label="label"
+                option-value="value"
+                :placeholder="$t('studyGroup.placeholder.chooseGroup')"
+                class="w-full"
+                :disabled="disableStudyGroupFilter"
+                :empty-message="$t('global.labels.noRecords')"
+                :max-selected-labels="1"
+                :selected-items-label="`{0} ${$t(
+                  'global.placeholder.optionsSelected',
+                )}`"
+              />
+            </div>
+            <div class="lg:col-span-2 flex flex-row items-center gap-2">
+              {{ $t('studyGroup.plural') }}:
+              <MultiSelect
+                v-model="filterObservationGroup"
+                :options="observationGroupOptions"
+                option-label="label"
+                option-value="value"
+                :placeholder="$t('observationGroup.placeholder.chooseGroup')"
+                class="w-full"
+                :disabled="disableObservationGroupFilter"
+                :empty-message="$t('global.labels.noRecords')"
+                :max-selected-labels="1"
+                :selected-items-label="`{0} ${$t(
+                  'global.placeholder.optionsSelected',
+                )}`"
+              />
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/subComponents/DataDownload.vue
+++ b/src/components/subComponents/DataDownload.vue
@@ -359,6 +359,7 @@
                 class="w-full"
                 :empty-message="$t('global.labels.noRecords')"
                 :max-selected-labels="1"
+                :disabled="disableStudyGroupFilter"
                 :selected-items-label="`{0} ${$t(
                   'global.placeholder.optionsSelected',
                 )}`"

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -1123,7 +1123,11 @@
         "delete": "Möchten Sie die Datenerhebungs-Gruppe wirklich löschen?"
       }
     },
+    "placeholder": {
+      "chooseGroup": "Gruppe wählen"
+    },
     "plural": "Datenerhebungs-Gruppen",
+    "singular": "Datenerhebungs-Gruppe",
     "groupList": {
       "description": "Datenerhebungs-Gruppen werden verwendet, um Teilnehmer:innen, Datenerhebungen und/oder Interventions zu gruppieren. Im Gegensatz zu den Studiengruppen, können diese multiplen Elementen zugewiesen werden. <b>Ein:e Teilnehmer:in, eine Datenerhebung und eine Intervention kann jeweils mehreren Datenerhebungs-Gruppen zugewiesen werden.</b> (Beisipel: Raucher, Diabetes Typ 2).",
       "placeholder": {
@@ -1161,7 +1165,7 @@
       }
     },
     "placeholder": {
-      "chooseGroup": "Studiengruppe auswählen"
+      "chooseGroup": "Gruppe wählen"
     },
     "plural": "Studiengruppen",
     "singular": "Studiengruppe"

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1122,7 +1122,11 @@
         "delete": "Do you really want to delete this observation group?"
       }
     },
+    "placeholder": {
+      "chooseGroup": "Choose a group"
+    },
     "plural": "Observation groups",
+    "singular": "Observation group",
     "groupList": {
       "description": "Observation groups are used to group participants, observations, and/or interventions. Unlike study groups, they can be assigned to multiple elements. <b>A participant, an observation, and an intervention can each be assigned to multiple observation groups.</b> (Example: smokers, type 2 diabetes).",
       "placeholder": {

--- a/src/models/DataDownloadModel.ts
+++ b/src/models/DataDownloadModel.ts
@@ -15,6 +15,7 @@ export interface DownloadDataFilter {
   studyGroupId?: number[];
   participantId?: number[];
   observationId?: number[];
+  observationGroupId?: number[];
   from?: string;
   to?: string;
 }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -20,16 +20,19 @@ import { useStudyStore } from '../stores/studyStore';
 import { useStudyGroupStore } from '../stores/studyGroupStore';
 import Integrations from '../views/Integrations.vue';
 import Timeline from '../views/Timeline.vue';
+import { useObservationGroupStore } from '../stores/observationGroupStore';
 
 const studyResolver = async (to: any, from: any, next: any): Promise<void> => {
   const studyStore = useStudyStore();
   const studyGroupStore = useStudyGroupStore();
+  const observationGroupStore = useObservationGroupStore();
   if (
     !studyStore.study.studyId ||
     studyStore.study.studyId !== to.params.studyId
   ) {
     await studyStore.getStudy(to.params.studyId);
     await studyGroupStore.getStudyGroups(to.params.studyId);
+    await observationGroupStore.getObservationGroups(to.params.studyId);
   }
   next();
 };

--- a/src/stores/studyStore.ts
+++ b/src/stores/studyStore.ts
@@ -188,6 +188,7 @@ export const useStudyStore = defineStore('study', () => {
     studyGroupId,
     participantId,
     observationId,
+    observationGroupId,
     from,
     to,
   }: DownloadData): Promise<void> {
@@ -209,6 +210,7 @@ export const useStudyStore = defineStore('study', () => {
               studyGroupId,
               participantId,
               observationId,
+              observationGroupId,
               from,
               to,
               { responseType: 'blob' },

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -10,9 +10,11 @@ Licensed under the Elastic License 2.0. */
   import { useStudyGroupStore } from '../stores/studyGroupStore';
   import { StudyRole } from '@gs';
   import TimelineList from '../components/TimelineList.vue';
+  import { useObservationGroupStore } from '../stores/observationGroupStore';
 
   const studyStore = useStudyStore();
   const studyGroupStore = useStudyGroupStore();
+  const observationGroupStore = useObservationGroupStore();
 
   const accessRoles: StudyRole[] = [
     StudyRole.StudyAdmin,
@@ -35,6 +37,7 @@ Licensed under the Elastic License 2.0. */
         <TimelineList
           :study-id="studyStore.studyId"
           :study-groups="studyGroupStore.studyGroups"
+          :observation-groups="observationGroupStore.observationGroups"
         ></TimelineList>
       </Suspense>
     </div>


### PR DESCRIPTION
Ticket: https://github.com/redlink-gmbh/umm-project/issues/271

- monitoring & data "studiendaten herunterladen" takes observation groups in api but the object in download json doesn't have an observation group id
- timeline only takes one value for observation group id -> extended timeline with simple filter logic

----
moitoring & data request for "erhobene daten" doesn't take any observation groups
--> we found some other bugs with the filter (don't work in any way), follow up bug ticket (won't be extended for now)
Bugticket: https://github.com/redlink-gmbh/more-studymanager-frontend/pull/12