### PR TITLE
#399: update goal template localization variables

### DIFF
--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -572,35 +572,6 @@
   "goaltemplate": {
     "property": {
       "global": {
-        "appTitle": {
-          "name": "App Ziel Titel",
-          "description": "Der Default-Name des Ziels, welcher auf der Teilnehmer:innen App angezeigt wird.",
-          "placeholder": "App Titel eingeben"
-        },
-        "appDescription": {
-          "name": "App Ziel Beschreibung",
-          "description": "Die Beschreibung des Ziels, welche auf der App den Teilnehmer:innen angezeigt wird. Halten Sie die Beschreibung so kurz wie möglich, da diese sonst zu viel Platz einnimmt.",
-          "placeholder": "Füge Kurzbeschreibung des Ziels hinzu"
-        },
-        "goalTitleState": {
-          "name": "Überschreiben des Titels",
-          "description": "Erlaubt den Teilnehmer:innen bei der Personalisierung auf der App den Zieltitel anzupassen.",
-          "placeholder": "Überschreiben erlauben"
-        },
-        "days-of-week": {
-          "name": "Wochentage",
-          "description": "Wochentage Bereich",
-          "placeholder-min": "Mindestwert",
-          "placeholder-max": "Maximalwert"
-        },
-        "self-report-time": {
-          "name": "Sendungs Zeitpunkt",
-          "description": "Dies ist der Zeitpunkt, zu dem die Benachricthigung an die Teilnehmer:innen gesendet wird.",
-          "placeholder": "Zeitpunkte auswählen"
-        }
-      },
-      "amountOfGoal": {
-        "partOfTemplate": "Teil der Vorschau",
         "section": {
           "configuration": {
             "name": "Zielkonfiguration",
@@ -619,6 +590,38 @@
             "description": "Hier können Sie zu einer bestimmten Zeit eine Benachrichtigung an die Teilnehmer:innen senden, um die Zielerreichung zu verifizieren."
           }
         },
+        "appTitle": {
+          "name": "App Ziel Titel",
+          "description": "Der Default-Name des Ziels, welcher auf der Teilnehmer:innen App angezeigt wird.",
+          "placeholder": "App Titel eingeben"
+        },
+        "appDescription": {
+          "name": "App Ziel Beschreibung",
+          "description": "Die Beschreibung des Ziels, welche auf der App den Teilnehmer:innen angezeigt wird. Halten Sie die Beschreibung so kurz wie möglich, da diese sonst zu viel Platz einnimmt.",
+          "placeholder": "Füge Kurzbeschreibung des Ziels hinzu"
+        },
+        "goalTitleState": {
+          "name": "Überschreiben des Titels",
+          "description": "Erlaubt den Teilnehmer:innen bei der Personalisierung auf der App den Zieltitel anzupassen.",
+          "placeholder": "Überschreiben erlauben"
+        },
+        "showAsTodoItemState": {
+          "name": "Verpflichtendes Ziel",
+          "description": "Dies ist ein verpflichtendes Ziel, das von den Teilnehmer:innen abgeschlossen werden muss."
+        },
+        "customShowAsTodoItemState": {
+          "name": "Benutzerdefiniertes verpflichtendes Ziel",
+          "description": "Dies ist ein benutzerdefiniertes verpflichtendes Ziel, das von den Teilnehmer:innen abgeschlossen werden muss."
+        },
+        "days-of-week": {
+          "name": "Wochentage",
+          "description": "Wochentage Bereich",
+          "placeholder-min": "Mindestwert",
+          "placeholder-max": "Maximalwert"
+        }
+      },
+      "amountOfGoal": {
+        "partOfTemplate": "Teil der Vorschau",
         "goal-preview": {
           "name": "Ziel Vorschau",
           "description": "Das Ziel wird auf der App folgendermaßen angezeigt:",
@@ -638,6 +641,28 @@
             "description": "Die Einheit für Zielwerte (z.B. Glas Wasser)",
             "placeholder": "Einheit eingeben"
           }
+        }
+      },
+      "boolean": {
+        "goal": {
+          "question": {
+            "name": "Zieltext",
+            "description": "Dies ist der Text, der den Patienten in der App angezeigt wird (z. B. wie die Vorschau von anderen Zielen mit komplexeren Eigenschaften).",
+            "placeholder": "Zieltext eingeben"
+          },
+          "desired": {
+            "name": "Gewünschtes Ergebnis",
+            "description": "Dies ist das gewünschte Ergebnis der Adhärenzprüfung (wahr, falsch)"
+          }
+        }
+      },
+      "reduceAmountOf": {
+        "goal": {
+          "activity": {
+            "name": "Aktion",
+            "description": "Was wird gemacht?",
+            "placeholder": "Aktion eingeben"
+          }
         },
         "status-100-reached": {
           "name": "100% erreicht",
@@ -654,11 +679,6 @@
           "description": "Text der zwischen 0 und 75% Zielerreichung angezeigt wird.",
           "placeholder": "Statustext für 'noch nicht erreicht' eingeben"
         },
-        "self-report-question": {
-          "name": "Fargetext",
-          "description": "Dies ist die Nachricht, die an die Teilnehmer:innen gesendet wird.",
-          "placeholder": "Fargetext eingeben"
-        },
         "status-day-not-consumed": {
           "name": "Nichts konsumiert",
           "description": "Dieser Status wird angezeigt, wenn an dem Tag nichts konsumiert wurde.",
@@ -673,15 +693,24 @@
           "name": "Über dem Limit",
           "description": "Dieser Status wird angezeigt, wenn das Limit überschritten wurde.",
           "placeholder": "Statustext für 'Über dem Limit' eingeben"
-        }
-      },
-      "reduceAmountOf": {
-        "goal": {
-          "activity": {
-            "name": "Aktion",
-            "description": "Was wird gemacht?",
-            "placeholder": "Aktion eingeben"
-          }
+        },
+        "self-report-time": {
+          "name": "Benachrichtigungszeitpunkt",
+          "description": "Dies ist der Zeitpunkt, zu dem die Benachrichtigung an die Teilnehmer:innen gesendet wird.",
+          "placeholder": "Zeitpunkte auswählen"
+        },
+        "customAdherenceChecksState": {
+          "name": "Benutzerdefinierte Adhärenzprüfung",
+          "description": "Ermöglicht es dem Patienten, die Standardeinstellungen für Adhärenzprüfungen zu überschreiben."
+        },
+        "adherenceChecksScheduleState": {
+          "name": "Benutzerdefinierte Adhärenzprüfung",
+          "description": "Ermöglicht es dem Patienten, die Standardeinstellungen für Adhärenzprüfungen zu überschreiben."
+        },
+        "self-report-question": {
+          "name": "Fragetext",
+          "description": "Dies ist die Nachricht, die an die Teilnehmer:innen gesendet wird.",
+          "placeholder": "Fragetext eingeben"
         }
       }
     },
@@ -741,7 +770,16 @@
       },
       "category": {
         "nutrition": "Ernährung",
-        "smoking": "Rauchen"
+        "smoking": "Rauchen",
+        "medication": "Medikamente"
+      },
+      "medication": {
+        "description": "Dieses Ziel hilft dabei, die Einnahme von Medikamenten zu verfolgen.",
+        "name": "Medikament"
+      },
+      "boolean": {
+        "description": "Dieses Ziel ist eine einfache Ja/Nein-Bedingung für ein benutzerdefiniertes Ziel.",
+        "name": "Ja/Nein-Bedingung"
       }
     },
     "goalTemplateList": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -572,35 +572,6 @@
   "goaltemplate": {
     "property": {
       "global": {
-        "appTitle": {
-          "name": "App Goal Title",
-          "description": "The default name of the goal displayed in the participant app.",
-          "placeholder": "Enter app title"
-        },
-        "appDescription": {
-          "name": "App Goal Description",
-          "description": "The description of the goal displayed to participants in the app. Keep the description as short as possible, otherwise it will take up too much space.",
-          "placeholder": "Add a short goal description"
-        },
-        "goalTitleState": {
-          "name": "Allow Title Override",
-          "description": "Allows participants to customize the goal title during personalization in the app.",
-          "placeholder": "Allow overriding"
-        },
-        "days-of-week": {
-          "name": "Days of the Week",
-          "description": "Days of the week range",
-          "placeholder-min": "Minimum value",
-          "placeholder-max": "Maximum value"
-        },
-        "self-report-time": {
-          "name": "Notification Time",
-          "description": "This is the time at which the notification is sent to participants.",
-          "placeholder": "Select times"
-        }
-      },
-      "amountOfGoal": {
-        "partOfTemplate": "Part of the preview",
         "section": {
           "configuration": {
             "name": "Goal Configuration",
@@ -619,6 +590,86 @@
             "description": "Here you can send a notification to participants at a specific time to verify goal achievement."
           }
         },
+        "appTitle": {
+          "name": "App Goal Title",
+          "description": "The default name of the goal displayed in the participant app.",
+          "placeholder": "Enter app title"
+        },
+        "appDescription": {
+          "name": "App Goal Description",
+          "description": "The description of the goal displayed to participants in the app. Keep the description as short as possible, otherwise it will take up too much space.",
+          "placeholder": "Add a short goal description"
+        },
+        "goalTitleState": {
+          "name": "Allow Title Override",
+          "description": "Allows participants to customize the goal title during personalization in the app.",
+          "placeholder": "Allow overriding"
+        },
+        "showAsTodoItemState": {
+          "name": "Mendatory Goal",
+          "description": "This is a mandatory goal that must be completed by the participant."
+        },
+        "customShowAsTodoItemState": {
+          "name": "Custom Mendatory Goal",
+          "description": "This is a custom mandatory goal that must be completed by the participant."
+        },
+        "days-of-week": {
+          "name": "Days of the Week",
+          "description": "Days of the week range",
+          "placeholder-min": "Minimum value",
+          "placeholder-max": "Maximum value"
+        },
+        "status-100-reached": {
+          "name": "100% Reached",
+          "description": "Text displayed when 100% of the goal is achieved.",
+          "placeholder": "Enter status text for '100%'"
+        },
+        "status-75-reached": {
+          "name": "75% Reached",
+          "description": "Text displayed when 75%+ of the goal is achieved.",
+          "placeholder": "Enter status text for '75%'"
+        },
+        "status-not-reached": {
+          "name": "Not Yet Reached",
+          "description": "Text displayed between 0 and 75% goal achievement.",
+          "placeholder": "Enter status text for 'not yet reached'"
+        },
+        "status-day-not-consumed": {
+          "name": "Nothing Consumed",
+          "description": "This status is displayed when nothing was consumed that day.",
+          "placeholder": "Enter status text for 'nothing consumed'"
+        },
+        "status-day-under-limit": {
+          "name": "Below the Limit",
+          "description": "This status is displayed when the participant is below the limit.",
+          "placeholder": "Enter status text for 'below the limit'"
+        },
+        "status-day-over-limit": {
+          "name": "Above the Limit",
+          "description": "This status is displayed when the limit has been exceeded.",
+          "placeholder": "Enter status text for 'above the limit'"
+        },
+        "self-report-time": {
+          "name": "Notification Time",
+          "description": "This is the time at which the notification is sent to participants.",
+          "placeholder": "Select times"
+        },
+        "customAdherenceChecksState": {
+          "name": "Custom Adherence Check",
+          "description": "Lets the patient overwrite the goals default settings for adherence checks."
+        },
+        "adherenceChecksScheduleState": {
+          "name": "Custom Adherence Check",
+          "description": "Lets the patient overwrite the goals default settings for adherence checks."
+        },
+        "self-report-question": {
+          "name": "Question Text",
+          "description": "This is the message sent to participants.",
+          "placeholder": "Enter question text"
+        }
+      },
+      "amountOfGoal": {
+        "partOfTemplate": "Part of the preview",
         "goal-preview": {
           "name": "Goal Preview",
           "description": "The goal is displayed in the app as follows:",
@@ -638,41 +689,19 @@
             "description": "The unit for goal values (e.g. glass of water)",
             "placeholder": "Enter unit"
           }
-        },
-        "status-100-reached": {
-          "name": "100% Reached",
-          "description": "Text displayed when 100% of the goal is achieved.",
-          "placeholder": "Enter status text for '100%'"
-        },
-        "status-75-reached": {
-          "name": "75% Reached",
-          "description": "Text displayed when 75%+ of the goal is achieved.",
-          "placeholder": "Enter status text for '75%'"
-        },
-        "status-not-reached": {
-          "name": "Not Yet Reached",
-          "description": "Text displayed between 0 and 75% goal achievement.",
-          "placeholder": "Enter status text for 'not yet reached'"
-        },
-        "self-report-question": {
-          "name": "Question Text",
-          "description": "This is the message sent to participants.",
-          "placeholder": "Enter question text"
-        },
-        "status-day-not-consumed": {
-          "name": "Nothing Consumed",
-          "description": "This status is displayed when nothing was consumed that day.",
-          "placeholder": "Enter status text for 'nothing consumed'"
-        },
-        "status-day-under-limit": {
-          "name": "Below the Limit",
-          "description": "This status is displayed when the participant is below the limit.",
-          "placeholder": "Enter status text for 'below the limit'"
-        },
-        "status-day-over-limit": {
-          "name": "Above the Limit",
-          "description": "This status is displayed when the limit has been exceeded.",
-          "placeholder": "Enter status text for 'above the limit'"
+        }
+      },
+      "boolean": {
+        "goal": {
+          "question": {
+            "name": "Goal Text",
+            "description": "This is the text displayed to patients in the app (e.g. like the Previewf from other goals with more complex properties)",
+            "placeholder": "Enter goal text"
+          },
+          "desired": {
+            "name": "Desired outcome",
+            "description": "This is the desired outcome of the adhearance check (true, false)"
+          }
         }
       },
       "reduceAmountOf": {
@@ -741,7 +770,16 @@
       },
       "category": {
         "nutrition": "Nutrition",
-        "smoking": "Smoking"
+        "smoking": "Smoking",
+        "medication": "Medication"
+      },
+      "medication": {
+        "description": "This goal helps to track adherance for medication.",
+        "name": "Medication"
+      },
+      "boolean": {
+        "description": "This goal is a simple yes/no condition, for defining a custom goal.",
+        "name": "Yes/No condition"
       }
     },
     "goalTemplateList": {


### PR DESCRIPTION
Mir sind noch paar Kleinigkeiten aufgefallen, die wir beim Umstellen übersehen haben:

Beim Boolean Goal, sollte der hier eine global prop sein:
```
goaltemplate.property.boolean.self-report-question.name
goaltemplate.property.boolean.self-report-question.description
```

Und dann gibts noch bei zwei goals ne prop Doppelung - evtl. gewollt? Oder ein Fehler. Ich konnte es jetzt nicht wirklich zuteilen, evtl schauts da morgen noch mal drauf. Es handelt sich um folgende Paare:

1. showAsTodoItemState & customShowAsTodoItemState:

```
"showAsTodoItemState": {
  "name": "Mendatory Goal",
  "description": "This is a mandatory goal that must be completed by the participant.",
},
"customShowAsTodoItemState": {
  "name": "Custom Mendatory Goal",
  "description": "This is a custom mandatory goal that must be completed by the participant.",
},
```

2. customAdherenceChecksState && adherenceChecksScheduleState

```
"customAdherenceChecksState": {
  "name": "Custom Adherence Check",
  "description": "Lets the patient overwrite the goals default settings for adherence checks."
},
"adherenceChecksScheduleState": {
  "name": "Custom Adherence Check",
  "description": "Lets the patient overwrite the goals default settings for adherence checks."
}
```
